### PR TITLE
curations: Change NuGet::NCrontab.Signed to NuGet::ncrontab.signed

### DIFF
--- a/curations/NuGet/_/ncrontab.signed.yml
+++ b/curations/NuGet/_/ncrontab.signed.yml
@@ -1,14 +1,14 @@
-- id: "NuGet::NCrontab.Signed:3.1.0"
+- id: "NuGet::ncrontab.signed:3.1.0"
   curations:
     comment: "Set the VCS revision because the tag does not exactly match the version."
     vcs:
       revision: "v3.1"
-- id: "NuGet::NCrontab.Signed:3.2.0"
+- id: "NuGet::ncrontab.signed:3.2.0"
   curations:
     comment: "Set the VCS revision because the tag does not exactly match the version."
     vcs:
       revision: "v3.2"
-- id: "NuGet::NCrontab.Signed:3.3.0"
+- id: "NuGet::ncrontab.signed:3.3.0"
   curations:
     comment: "Set the VCS revision because the tag does not exactly match the version."
     vcs:


### PR DESCRIPTION
The package was renamed to use uppercase with the latest release 3.3.2,
but all curations affect the previous versions where the lowercase name
was used.