### PR TITLE
Add a VCS curation for "Maven:bsf:bsf"

### DIFF
--- a/curations/Maven/bsf/bsf.yml
+++ b/curations/Maven/bsf/bsf.yml
@@ -1,0 +1,7 @@
+- id: "Maven:bsf:bsf"
+  curations:
+    comment: |
+      The source code repository has moved from Subversion to Git.
+    vcs:
+      type: "Git"
+      url: "https://gitbox.apache.org/repos/asf/commons-bsf"


### PR DESCRIPTION
See [1].

[1]: https://commons.apache.org/proper/commons-bsf/source-repository.html

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>