### PR TITLE
Add a VCS curation for "Maven:com.github.klangfarbe:statechart"

### DIFF
--- a/curations/Maven/com.github.klangfarbe/statechart.yml
+++ b/curations/Maven/com.github.klangfarbe/statechart.yml
@@ -1,0 +1,8 @@
+- id: "Maven:com.github.klangfarbe:statechart"
+  curations:
+    comment: |
+      No sources artifact is published, and also no SCM tag is in the POM. The
+      GitHub project page was found via Internet search.
+    vcs:
+      type: "Git"
+      url: "https://github.com/klangfarbe/UML-Statechart-Framework-for-Java.git"


### PR DESCRIPTION
Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>