### PR TITLE
Add a VCS URL curation for the `j1939` PyPI package

### DIFF
--- a/curations/PyPI/_/j1939.yml
+++ b/curations/PyPI/_/j1939.yml
@@ -1,0 +1,5 @@
+- id: "PyPI::j1939:"
+  curations:
+    comment: The correct VCS URL was found via https://pypi.org/project/j1939/.
+    vcs:
+      url: https://github.com/benkfra/j1939.git


### PR DESCRIPTION
This is specifically for `PyPI::j1939:0.1.0.dev1` as `v0.1.0-dev1` is
the only tag in the repository.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@bosch.io>