### PR TITLE
Re-align the version strings for Go packages

### DIFF
--- a/package-configurations/Go/_/github.com%2Fgorilla%2Fmux/1.7.2/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fgorilla%2Fmux/1.7.2/vcs.yml
@@ -1,5 +1,5 @@
 ---
-id: "Go::github.com/gorilla/mux:v1.7.2"
+id: "Go::github.com/gorilla/mux:1.7.2"
 vcs:
   type: "Git"
   url: "https://github.com/gorilla/mux.git"

--- a/package-configurations/Go/_/github.com%2Fgorilla%2Fmux/1.8.0/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fgorilla%2Fmux/1.8.0/vcs.yml
@@ -1,5 +1,5 @@
 ---
-id: "Go::github.com/gorilla/mux:v1.8.0"
+id: "Go::github.com/gorilla/mux:1.8.0"
 vcs:
   type: "Git"
   url: "https://github.com/gorilla/mux.git"

--- a/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.0.0/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.0.0/vcs.yml
@@ -1,9 +1,9 @@
 ---
-id: "Go::github.com/spf13/cobra:v1.3.0"
+id: "Go::github.com/spf13/cobra:1.0.0"
 vcs:
   type: "Git"
   url: "https://github.com/spf13/cobra.git"
-  revision: "bfacc59f62c67ffd43e93655a8d933cefab0fa99"
+  revision: "a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d"
 path_excludes:
   - pattern: "doc/**"
     reason: "DOCUMENTATION_OF"
@@ -15,10 +15,10 @@ license_finding_curations:
   - path: "cobra/README.md"
     concluded_license: "Apache-2.0"
     reason: "DOCUMENTATION_OF"
-    comment: "Match on sentence 'For example, GPLv2, GPLv3, LGPL, AGPL, MIT, 2-Clause BSD or 3-Clause BSD'."
+    comment: "Match on 'For example, GPLv2, GPLv3, LGPL, AGPL, MIT, 2-Clause BSD or 3-Clause BSD'."
   - path: "cobra/cmd/license*"
     concluded_license: "Apache-2.0"
     reason: "INCORRECT"
     comment:
       "License files were included to enable developers to easily generate their own OSS licensed CLIs, see \
-      https://github.com/spf13/cobra/blob/v1.2.1/cobra/README.md#configuring-the-cobra-generator."
+      https://github.com/spf13/cobra/blob/v1.0.0/cobra/README.md#configuring-the-cobra-generator."

--- a/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.2.1/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.2.1/vcs.yml
@@ -1,5 +1,5 @@
 ---
-id: "Go::github.com/spf13/cobra:v1.2.1"
+id: "Go::github.com/spf13/cobra:1.2.1"
 vcs:
   type: "Git"
   url: "https://github.com/spf13/cobra.git"

--- a/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.3.0/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fspf13%2Fcobra/1.3.0/vcs.yml
@@ -1,9 +1,9 @@
 ---
-id: "Go::github.com/spf13/cobra:v1.0.0"
+id: "Go::github.com/spf13/cobra:1.3.0"
 vcs:
   type: "Git"
   url: "https://github.com/spf13/cobra.git"
-  revision: "a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d"
+  revision: "bfacc59f62c67ffd43e93655a8d933cefab0fa99"
 path_excludes:
   - pattern: "doc/**"
     reason: "DOCUMENTATION_OF"
@@ -15,10 +15,10 @@ license_finding_curations:
   - path: "cobra/README.md"
     concluded_license: "Apache-2.0"
     reason: "DOCUMENTATION_OF"
-    comment: "Match on 'For example, GPLv2, GPLv3, LGPL, AGPL, MIT, 2-Clause BSD or 3-Clause BSD'."
+    comment: "Match on sentence 'For example, GPLv2, GPLv3, LGPL, AGPL, MIT, 2-Clause BSD or 3-Clause BSD'."
   - path: "cobra/cmd/license*"
     concluded_license: "Apache-2.0"
     reason: "INCORRECT"
     comment:
       "License files were included to enable developers to easily generate their own OSS licensed CLIs, see \
-      https://github.com/spf13/cobra/blob/v1.0.0/cobra/README.md#configuring-the-cobra-generator."
+      https://github.com/spf13/cobra/blob/v1.2.1/cobra/README.md#configuring-the-cobra-generator."

--- a/package-configurations/Go/_/github.com%2Fspf13%2Fpflag/1.0.3/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fspf13%2Fpflag/1.0.3/vcs.yml
@@ -1,9 +1,9 @@
 ---
-id: "Go::github.com/spf13/pflag:v1.0.5"
+id: "Go::github.com/spf13/pflag:1.0.3"
 vcs:
   type: "Git"
   url: "https://github.com/spf13/pflag.git"
-  revision: "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  revision: "298182f68c66c05229eb03ac171abe6e309ee79a"
 path_excludes:
   - pattern: "*_test.go"
     reason: "TEST_OF"
@@ -13,4 +13,4 @@ license_finding_curations:
     reason: "INCORRECT"
     comment:
       "Match on 'Use of this source code ds governed by a BSD-style license' \
-      in https://github.com/spf13/pflag/blob/v1.0.5/duration_slice_test.go#L2-L3."
+      in https://github.com/spf13/pflag/blob/v1.0.3/duration_slice_test.go#L2-L3."

--- a/package-configurations/Go/_/github.com%2Fspf13%2Fpflag/1.0.5/vcs.yml
+++ b/package-configurations/Go/_/github.com%2Fspf13%2Fpflag/1.0.5/vcs.yml
@@ -1,9 +1,9 @@
 ---
-id: "Go::github.com/spf13/pflag:v1.0.3"
+id: "Go::github.com/spf13/pflag:1.0.5"
 vcs:
   type: "Git"
   url: "https://github.com/spf13/pflag.git"
-  revision: "298182f68c66c05229eb03ac171abe6e309ee79a"
+  revision: "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
 path_excludes:
   - pattern: "*_test.go"
     reason: "TEST_OF"
@@ -13,4 +13,4 @@ license_finding_curations:
     reason: "INCORRECT"
     comment:
       "Match on 'Use of this source code ds governed by a BSD-style license' \
-      in https://github.com/spf13/pflag/blob/v1.0.3/duration_slice_test.go#L2-L3."
+      in https://github.com/spf13/pflag/blob/v1.0.5/duration_slice_test.go#L2-L3."


### PR DESCRIPTION
The versions have been normalized to be valid semver versions, see also
https://github.com/oss-review-toolkit/ort/pull/5586 and https://github.com/oss-review-toolkit/ort/issues/5532.
