### PR TITLE
example.rules.kts: Access the given `OrtResult` in a single way

### DIFF
--- a/evaluator-rules/src/main/resources/example.rules.kts
+++ b/evaluator-rules/src/main/resources/example.rules.kts
@@ -935,7 +935,7 @@ fun PackageRule.hasDefinitionFileName(vararg definitionFileNames: String) =
         override val description = "hasDefinitionFileName(${matchingNames.joinToString()})"
 
         override fun matches(): Boolean {
-            val project = ruleSet.ortResult.getProject(pkg.id)
+            val project = ortResult.getProject(pkg.id)
             if (project == null) return false
 
             return project.definitionFilePath.substringAfterLast('/') in matchingNames


### PR DESCRIPTION
The evaluator injects the (top-level) property named `ortResult` into
the policy rules script aka `rules.kts`. Align on always using that
property for accessing the `OrtResult` instance.

Note: This was spotted in context of https://github.com/oss-review-toolkit/ort/issues/5621.