### PR TITLE
evaluator-rules: Pull in all missing rules from ORT's example rules

### DIFF
--- a/evaluator-rules/src/main/resources/example.rules.kts
+++ b/evaluator-rules/src/main/resources/example.rules.kts
@@ -65,7 +65,7 @@ val publicDomainLicenses = licenseClassifications.licensesByCategory["public-dom
 /**
  * List of licenses approved by organization to be used for its open source projects.
  */
-val OrgOssProjectsApprovedLicenses = listOf(
+val orgOssProjectsApprovedLicenses = listOf(
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
@@ -208,7 +208,7 @@ fun getVcsMdLink(pkg: Package) : String {
 /**
  * Return true if [license] is on the list of the organization's approved licenses for its open source projects.
  */
-fun isApprovedOrgOssProjectLicense(license: SpdxSingleLicenseExpression) = license in OrgOssProjectsApprovedLicenses
+fun isApprovedOrgOssProjectLicense(license: SpdxSingleLicenseExpression) = license in orgOssProjectsApprovedLicenses
 
 /**
  * Return true if a label with identical [key] exists whose comma separate values contains [value].

--- a/evaluator-rules/src/main/resources/example.rules.kts
+++ b/evaluator-rules/src/main/resources/example.rules.kts
@@ -1276,7 +1276,7 @@ fun RuleSet.wrongLicenseInLicenseFileRule() = projectSourceRule("WRONG_LICENSE_I
         +projectSourceHasFile("LICENSE")
     }
 
-    val allowedRootLicenses = setOf("Apackage-2.0", "MIT")
+    val allowedRootLicenses = orgOssProjectsApprovedLicenses.mapTo(mutableSetOf()) { it.simpleLicense() }
     val detectedRootLicenses = projectSourceGetDetectedLicensesByFilePath("LICENSE").values.flatten().toSet()
     val wrongLicenses = detectedRootLicenses - allowedRootLicenses
 


### PR DESCRIPTION
The evaluator rules in this repository have been created based on ORT's example policy rules, meanwhile they deviated, but are quite redundant. Reduce the deviation use-case-wise by copying all rules from ORT's examples which are missing in this repository using ORT revision [1].

This is the first step towards making the 'ort-config' repository the single dedicated place to examplify policy rules. In the following ORT's example rules will be deleted, or rather minimized and turned into functional test assets, see also [2].

Note: The copied rules have been created as part of [3].

[1] 63e002ba57e7d49c96017fac2ff679de8a5b76df
[2] https://github.com/oss-review-toolkit/ort/issues/5701 
[3] https://github.com/oss-review-toolkit/ort/issues/5621

Part of: https://github.com/oss-review-toolkit/ort/issues/5621.

