### PR TITLE
tools/curations: Make several Gradle tasks non-abstract

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1,364 +1,10700 @@
+#
+# This ORT configuration file is provided as an example only. It
+# demonstrates the general configuration capabilities of ORT and does not
+# reflect any real-world configuration used by the ORT contributors, nor
+# are they a recommendation on the configuration to use.
+#
+# Please consult your legal counsel about how ORT should be configured for your use cases.
+#
 ---
-# Example license-classifications.yml based on categorization from
-# https://github.com/nexB/scancode-toolkit/commit/ed644e4.
-#
-# To demonstrate how one can insert a custom written offer
-# include-source-code-offer-in-notice-file has been set to
-# true for all licenses of the GPL family.
-#
-# For detailed documentation on this file, see
-# https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-license-classifications-yml.md.
-
 categories:
+- name: "commercial"
 - name: "copyleft"
-- name: "strong-copyleft"
 - name: "copyleft-limited"
+- name: "free-restricted"
+- name: "generic"
+- name: "patent-license"
 - name: "permissive"
-  description: "Licenses with permissive obligations."
+- name: "proprietary-free"
 - name: "public-domain"
-- name: "include-in-notice-file"
-  description: >-
-    This category is checked by templates used by the ORT report generator. The licenses associated with this
-    category are included into NOTICE files.
-- name: "include-source-code-offer-in-notice-file"
-  description: >-
-    A marker category that indicates that the licenses assigned to it require that the source code of the packages
-    needs to be provided.
-
+- name: "source-available"
+- name: "unknown"
+- name: "unstated-license"
 categorizations:
-- id: "AGPL-1.0"
+- id: "0BSD"
   categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "permissive"
+- id: "AAL"
+  categories:
+  - "permissive"
+- id: "ADSL"
+  categories:
+  - "permissive"
+- id: "AFL-1.1"
+  categories:
+  - "permissive"
+- id: "AFL-1.2"
+  categories:
+  - "permissive"
+- id: "AFL-2.0"
+  categories:
+  - "permissive"
+- id: "AFL-2.1"
+  categories:
+  - "permissive"
+- id: "AFL-3.0"
+  categories:
+  - "permissive"
 - id: "AGPL-1.0-only"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-1.0-or-later"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "AGPL-3.0"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-3.0-only"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "AGPL-3.0-or-later"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+- id: "AMDPLPA"
+  categories:
+  - "permissive"
+- id: "AML"
+  categories:
+  - "permissive"
+- id: "AMPAS"
+  categories:
+  - "permissive"
+- id: "ANTLR-PD"
+  categories:
+  - "permissive"
+- id: "ANTLR-PD-fallback"
+  categories:
+  - "public-domain"
+- id: "APAFML"
+  categories:
+  - "permissive"
+- id: "APL-1.0"
+  categories:
+  - "copyleft"
+- id: "APSL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "APSL-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "APSL-1.2"
+  categories:
+  - "copyleft-limited"
+- id: "APSL-2.0"
+  categories:
+  - "copyleft-limited"
+- id: "Abstyles"
+  categories:
+  - "permissive"
+- id: "Adobe-2006"
+  categories:
+  - "permissive"
+- id: "Adobe-Glyph"
+  categories:
+  - "permissive"
+- id: "Afmparse"
+  categories:
+  - "permissive"
+- id: "Aladdin"
+  categories:
+  - "copyleft"
+- id: "Apache-1.0"
+  categories:
+  - "permissive"
+- id: "Apache-1.1"
+  categories:
+  - "permissive"
 - id: "Apache-2.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "App-s2p"
+  categories:
+  - "permissive"
+- id: "Arphic-1999"
+  categories:
+  - "copyleft"
 - id: "Artistic-1.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
+- id: "Artistic-1.0-Perl"
+  categories:
+  - "copyleft-limited"
+- id: "Artistic-1.0-cl8"
+  categories:
+  - "copyleft-limited"
 - id: "Artistic-2.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "BSD-1-Clause"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "BSD-2-Clause"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "BSD-2-Clause-FreeBSD"
+- id: "BSD-2-Clause-Patent"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "BSD-2-Clause-NetBSD"
+- id: "BSD-2-Clause-Views"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "BSD-3-Clause"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "BSD-3-Clause-Attribution"
+  categories:
+  - "permissive"
+- id: "BSD-3-Clause-Clear"
+  categories:
+  - "permissive"
+- id: "BSD-3-Clause-LBNL"
+  categories:
+  - "permissive"
+- id: "BSD-3-Clause-Modification"
+  categories:
+  - "permissive"
+- id: "BSD-3-Clause-No-Military-License"
+  categories:
+  - "free-restricted"
+- id: "BSD-3-Clause-No-Nuclear-License"
+  categories:
+  - "free-restricted"
+- id: "BSD-3-Clause-No-Nuclear-License-2014"
+  categories:
+  - "free-restricted"
+- id: "BSD-3-Clause-No-Nuclear-Warranty"
+  categories:
+  - "free-restricted"
+- id: "BSD-3-Clause-Open-MPI"
+  categories:
+  - "permissive"
 - id: "BSD-4-Clause"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "BSD-4-Clause-Shortened"
+  categories:
+  - "permissive"
 - id: "BSD-4-Clause-UC"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "BSD-Protection"
+  categories:
+  - "copyleft"
+- id: "BSD-Source-Code"
+  categories:
+  - "permissive"
+- id: "BSL-1.0"
+  categories:
+  - "permissive"
+- id: "BUSL-1.1"
+  categories:
+  - "source-available"
+- id: "Baekmuk"
+  categories:
+  - "permissive"
+- id: "Bahyph"
+  categories:
+  - "permissive"
+- id: "Barr"
+  categories:
+  - "permissive"
+- id: "Beerware"
+  categories:
+  - "permissive"
+- id: "BitTorrent-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "BitTorrent-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "Bitstream-Vera"
+  categories:
+  - "permissive"
+- id: "BlueOak-1.0.0"
+  categories:
+  - "permissive"
+- id: "Borceux"
+  categories:
+  - "permissive"
+- id: "C-UDA-1.0"
+  categories:
+  - "free-restricted"
+- id: "CAL-1.0"
+  categories:
+  - "copyleft"
+- id: "CAL-1.0-Combined-Work-Exception"
+  categories:
+  - "copyleft-limited"
+- id: "CATOSL-1.1"
+  categories:
+  - "copyleft-limited"
 - id: "CC-BY-1.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "CC-BY-2.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "CC-BY-2.5"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "CC-BY-2.5-AU"
+  categories:
+  - "permissive"
 - id: "CC-BY-3.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "CC-BY-3.0-AT"
+  categories:
+  - "permissive"
+- id: "CC-BY-3.0-DE"
+  categories:
+  - "permissive"
+- id: "CC-BY-3.0-NL"
+  categories:
+  - "permissive"
+- id: "CC-BY-3.0-US"
+  categories:
+  - "permissive"
 - id: "CC-BY-4.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "CC-BY-NC-1.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-2.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-2.5"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-3.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-3.0-DE"
+  categories:
+  - "free-restricted"
+- id: "CC-BY-NC-4.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-1.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-2.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-2.5"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-3.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-3.0-DE"
+  categories:
+  - "free-restricted"
+- id: "CC-BY-NC-ND-3.0-IGO"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-ND-4.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-1.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-2.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-2.0-FR"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-2.0-UK"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-2.5"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-3.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-3.0-DE"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-3.0-IGO"
+  categories:
+  - "source-available"
+- id: "CC-BY-NC-SA-4.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-ND-1.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-ND-2.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-ND-2.5"
+  categories:
+  - "source-available"
+- id: "CC-BY-ND-3.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-ND-3.0-DE"
+  categories:
+  - "free-restricted"
+- id: "CC-BY-ND-4.0"
+  categories:
+  - "source-available"
+- id: "CC-BY-SA-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-2.0"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-2.0-UK"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-2.1-JP"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-2.5"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-3.0"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-3.0-AT"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-3.0-DE"
+  categories:
+  - "copyleft-limited"
+- id: "CC-BY-SA-4.0"
+  categories:
+  - "copyleft-limited"
+- id: "CC-PDDC"
+  categories:
+  - "public-domain"
 - id: "CC0-1.0"
   categories:
   - "public-domain"
-  - "include-in-notice-file"
 - id: "CDDL-1.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "CDDL-1.1"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
+- id: "CDL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "CDLA-Permissive-1.0"
+  categories:
+  - "permissive"
+- id: "CDLA-Permissive-2.0"
+  categories:
+  - "permissive"
+- id: "CDLA-Sharing-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "CECILL-1.0"
+  categories:
+  - "copyleft"
+- id: "CECILL-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "CECILL-2.0"
+  categories:
+  - "copyleft-limited"
+- id: "CECILL-2.1"
+  categories:
+  - "copyleft-limited"
+- id: "CECILL-B"
+  categories:
+  - "permissive"
+- id: "CECILL-C"
+  categories:
+  - "copyleft"
+- id: "CERN-OHL-1.1"
+  categories:
+  - "permissive"
+- id: "CERN-OHL-1.2"
+  categories:
+  - "permissive"
+- id: "CERN-OHL-P-2.0"
+  categories:
+  - "permissive"
+- id: "CERN-OHL-S-2.0"
+  categories:
+  - "copyleft"
+- id: "CERN-OHL-W-2.0"
+  categories:
+  - "copyleft-limited"
+- id: "CNRI-Jython"
+  categories:
+  - "permissive"
+- id: "CNRI-Python"
+  categories:
+  - "permissive"
+- id: "CNRI-Python-GPL-Compatible"
+  categories:
+  - "permissive"
+- id: "COIL-1.0"
+  categories:
+  - "permissive"
+- id: "CPAL-1.0"
+  categories:
+  - "copyleft"
+- id: "CPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "CPOL-1.02"
+  categories:
+  - "free-restricted"
+- id: "CUA-OPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "Caldera"
+  categories:
+  - "permissive"
+- id: "ClArtistic"
+  categories:
+  - "copyleft-limited"
+- id: "Community-Spec-1.0"
+  categories:
+  - "permissive"
+- id: "Condor-1.1"
+  categories:
+  - "permissive"
+- id: "Crossword"
+  categories:
+  - "permissive"
+- id: "CrystalStacker"
+  categories:
+  - "permissive"
+- id: "Cube"
+  categories:
+  - "permissive"
+- id: "D-FSL-1.0"
+  categories:
+  - "copyleft"
+- id: "DL-DE-BY-2.0"
+  categories:
+  - "permissive"
+- id: "DOC"
+  categories:
+  - "permissive"
+- id: "DRL-1.0"
+  categories:
+  - "permissive"
+- id: "DSDP"
+  categories:
+  - "permissive"
+- id: "Dotseqn"
+  categories:
+  - "permissive"
+- id: "ECL-1.0"
+  categories:
+  - "permissive"
+- id: "ECL-2.0"
+  categories:
+  - "permissive"
+- id: "EFL-1.0"
+  categories:
+  - "permissive"
+- id: "EFL-2.0"
+  categories:
+  - "permissive"
+- id: "EPICS"
+  categories:
+  - "permissive"
 - id: "EPL-1.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "EPL-2.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
+- id: "EUDatagrid"
+  categories:
+  - "permissive"
+- id: "EUPL-1.0"
+  categories:
+  - "copyleft"
 - id: "EUPL-1.1"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "EUPL-1.2"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-- id: "GPL-1.0+"
+- id: "Elastic-2.0"
+  categories:
+  - "source-available"
+- id: "Entessa"
+  categories:
+  - "permissive"
+- id: "ErlPL-1.1"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+- id: "Eurosym"
+  categories:
+  - "copyleft-limited"
+- id: "FDK-AAC"
+  categories:
+  - "copyleft-limited"
+- id: "FSFAP"
+  categories:
+  - "permissive"
+- id: "FSFUL"
+  categories:
+  - "public-domain"
+- id: "FSFULLR"
+  categories:
+  - "permissive"
+- id: "FTL"
+  categories:
+  - "permissive"
+- id: "Fair"
+  categories:
+  - "permissive"
+- id: "Frameworx-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "FreeBSD-DOC"
+  categories:
+  - "permissive"
+- id: "FreeImage"
+  categories:
+  - "copyleft-limited"
+- id: "GD"
+  categories:
+  - "permissive"
+- id: "GFDL-1.1-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.1-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.1-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.1-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.1-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.1-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.2-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-only"
+  categories:
+  - "copyleft-limited"
+- id: "GFDL-1.3-or-later"
+  categories:
+  - "copyleft-limited"
+- id: "GL2PS"
+  categories:
+  - "copyleft-limited"
+- id: "GLWTPL"
+  categories:
+  - "permissive"
 - id: "GPL-1.0-only"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-1.0-or-later"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0+"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0-only WITH Classpath-exception-2.0"
-  categories:
-  - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0-only WITH Font-exception-2.0"
-  categories:
-  - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-or-later"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-3.0"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-3.0+"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0-only"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-3.0-or-later"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+- id: "Giftware"
+  categories:
+  - "permissive"
+- id: "Glide"
+  categories:
+  - "copyleft"
+- id: "Glulxe"
+  categories:
+  - "permissive"
+- id: "HPND"
+  categories:
+  - "permissive"
+- id: "HPND-sell-variant"
+  categories:
+  - "permissive"
+- id: "HTMLTIDY"
+  categories:
+  - "permissive"
+- id: "HaskellReport"
+  categories:
+  - "permissive"
+- id: "Hippocratic-2.1"
+  categories:
+  - "free-restricted"
+- id: "IBM-pibs"
+  categories:
+  - "permissive"
+- id: "ICU"
+  categories:
+  - "permissive"
+- id: "IJG"
+  categories:
+  - "permissive"
+- id: "IPA"
+  categories:
+  - "copyleft-limited"
+- id: "IPL-1.0"
+  categories:
+  - "copyleft-limited"
 - id: "ISC"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "ImageMagick"
+  categories:
+  - "permissive"
+- id: "Imlib2"
+  categories:
+  - "copyleft-limited"
+- id: "Info-ZIP"
+  categories:
+  - "permissive"
+- id: "Intel"
+  categories:
+  - "permissive"
+- id: "Intel-ACPI"
+  categories:
+  - "permissive"
+- id: "Interbase-1.0"
+  categories:
+  - "copyleft"
+- id: "JPNIC"
+  categories:
+  - "permissive"
 - id: "JSON"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "Jam"
+  categories:
+  - "permissive"
+- id: "JasPer-2.0"
+  categories:
+  - "permissive"
+- id: "KiCad-libraries-exception"
+  categories:
+  - "copyleft-limited"
+- id: "LAL-1.2"
+  categories:
+  - "copyleft"
+- id: "LAL-1.3"
+  categories:
+  - "copyleft"
 - id: "LGPL-2.0-only"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "LGPL-2.0-or-later"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.1-only"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.1-or-later"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-3.0-only"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-3.0-or-later"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+- id: "LGPLLR"
+  categories:
+  - "copyleft-limited"
+- id: "LPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LPL-1.02"
+  categories:
+  - "copyleft-limited"
+- id: "LPPL-1.0"
+  categories:
+  - "copyleft"
+- id: "LPPL-1.1"
+  categories:
+  - "copyleft"
+- id: "LPPL-1.2"
+  categories:
+  - "copyleft"
+- id: "LPPL-1.3a"
+  categories:
+  - "copyleft"
+- id: "LPPL-1.3c"
+  categories:
+  - "copyleft"
+- id: "Latex2e"
+  categories:
+  - "permissive"
+- id: "Leptonica"
+  categories:
+  - "permissive"
+- id: "LiLiQ-P-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LiLiQ-R-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LiLiQ-Rplus-1.1"
+  categories:
+  - "copyleft"
 - id: "Libpng"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "LicenseRef-.amazon.com.-AmznSL-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-3com-microcode"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-3dslicer-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-4suite-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-996-icu-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-Hippocratic-3.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-abrms"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ac3filter"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-accellera-systemc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-acroname-bdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-activestate-community"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-activestate-community-2012"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-activestate-komodo-edit"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-actuate-birt-ihub-ftype-sla"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adaptec-downloadable"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adaptec-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-addthis-mobile-sdk-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adi-bsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-adobe-acrobat-reader-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-air-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-air-sdk-2014"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-color-profile-bundling"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-color-profile-license"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-dng-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-dng-spec-patent"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-adobe-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-adobe-flash-player-eula-21.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-flex-4-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-flex-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-general-tou"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-adobe-indesign-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adobe-postscript"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-adrian"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-aes-128-3.0"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-afpl-9.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-agentxpp"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-agere-bsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-agere-sla"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ago-private-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-agpl-2.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-aladdin-md5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-alasir"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-alexisisaac-freeware"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-allen-institute-software-2018"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-altermime"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-altova-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-amazon-redshift-jdbc"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-amd-historical"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-amd-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-amd-linux-firmware-export"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-amlogic-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ams-fonts"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-android-sdk-2009"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-android-sdk-2012"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-android-sdk-2021"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-android-sdk-license"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-android-sdk-preview-2015"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-anepokis-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-anti-capitalist-1.4"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-anu-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-aop-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-apache-due-credit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-apl-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-appfire-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-apple-attribution"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-apple-attribution-1997"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-apple-excl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-apple-mfi-license"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-apple-mpeg-4"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-apple-sscl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-appsflyer-framework"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-aptana-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-arachni-psl-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-aravindan-premkumar"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-argouml"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-arm-cortex-mx"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-arm-llvm-sga"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-array-input-method-pl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-artistic-1988-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-aslp"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-aslr"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-asmus"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-asn1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ati-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-atkinson-hyperlegible-font"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-atlassian-marketplace-tou"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-atmel-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-atmel-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-atmel-microcontroller"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-atmosphere-0.4"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-autoit-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-bakoma-fonts-1995"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bapl-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-bea-2.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-beal-screamer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bigdigits"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bigelow-holmes"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-binary-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-binary-linux-firmware-patent"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-biopython"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-biosl-4.0"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-bittorrent-1.2"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-bittorrent-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-bitwarden-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-bitzi-pd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-blas-2017"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-blitz-artistic"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-bloomberg-blpapi"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-bohl-0.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-boost-original"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bpel4ws-spec"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-bpmn-io"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-brad-martinez-vb-32"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-brent-corkum"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-brian-clapper"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-brian-gladman"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-brian-gladman-3-clause"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-brian-gladman-dual"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-broadcom-cfe"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-broadcom-commercial"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-broadcom-confidential"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-broadcom-dual"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-broadcom-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-broadcom-linux-timer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-broadcom-proprietary"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-broadcom-raspberry-pi"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-broadcom-standard-terms"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-broadcom-unpublished-source"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-broadcom-wiced"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-broadleaf-fair-use"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-brocade-firmware"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bruno-podetti"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-1-clause-build"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-1988"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-2-clause-freebsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-2-clause-netbsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-2-clause-plus-advertizing"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-devine"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-fda"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-jtag"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-no-change"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-no-trademark"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-3-clause-sun"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-ack-carrot2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-artwork"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-atmel"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-axis"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-axis-nomod"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-credit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-dpt"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-export"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-innosys"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-intel"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-mylex"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-new-derivative"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-new-nomod"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-new-tcpdump"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-no-disclaimer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-no-disclaimer-unmodified"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-no-mod"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-bsd-original-muscle"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-original-uc-1986"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-original-uc-1990"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-original-voices"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-plus-mod-notice"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-simplified-darwin"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-simplified-intel"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-simplified-source"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-top"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-top-gpl-addition"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-unchanged"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-unmodified"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsd-x11"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsl-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-bsla"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bsla-no-advert"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bugsense-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-bytemark"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-bzip2-libbzip-1.0.5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-c-fsl-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cadence-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-can-ogl-alberta-2.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-can-ogl-british-columbia-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-can-ogl-nova-scotia-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-can-ogl-ontario-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-can-ogl-toronto-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-careware"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-carnegie-mellon"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-carnegie-mellon-contributors"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cavium-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cavium-malloc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cavium-targeted-hardware"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-cc-by-2.0-uk"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cc-by-nc-nd-2.0-at"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-cc-by-nc-nd-2.0-au"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-cc-by-nc-sa-3.0-us"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-cc-devnations-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cc-gpl-2.0-pt"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-cc-lgpl-2.1-pt"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cc-nc-sampling-plus-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cc-pdm-1.0"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-cc-sampling-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cc-sampling-plus-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cclrc"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ccrc-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-cecill-1.0-en"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-cecill-2.0-fr"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cecill-2.1-fr"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cecill-b-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cecill-c-en"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cern-attribution-1995"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cgic"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-chartdirector-6.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-chelsio-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-chicken-dl-0.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-chris-maunder"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-chris-stoy"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-christopher-velazquez"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-classic-vb"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-classworlds"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-clear-bsd-1-clause"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-click-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cloudera-express"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cmigemo"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cmr-no"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cmu-computing-services"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cmu-mit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cmu-simple"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cmu-template"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cncf-corporate-cla-1.0"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-cncf-individual-cla-1.0"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-cockroach"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-code-credit-license-1.0.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-codeguru-permissions"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-codesourcery-2004"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-codexia"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cognitive-web-osl-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-colt"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-com-oreilly-servlet"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-commercial-license"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-commercial-option"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-commonj-timer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-compass"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-componentace-jcraft"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-concursive-pl-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-confluent-community-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-cooperative-non-violent-4.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-copyheart"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-corporate-accountability-1.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cosl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cosli"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-couchbase-community"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-couchbase-enterprise"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cpl-0.5"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-cpm-2022"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cpol-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-cpp-core-guidelines"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-crapl-0.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-crashlytics-agreement-2018"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-crcalc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-crypto-keys-redistribution"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-cryptopp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-csla"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-csprng"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ctl-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cubiware-software-1.0"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-cups"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-cve-tou"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cvwl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-cwe-tou"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cximage"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-cypress-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-d-fsl-1.0-en"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-d-zlib"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-damail"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dante-treglia"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-datamekanix-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-day-spec"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-dbad"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-dbad-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dbcl-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-dco-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-defensive-patent-1.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-dejavu-font"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-delorie-historical"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dennis-ferguson"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-devblocks-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-dgraph-cla"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-dhtmlab-public"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-digia-qt-commercial"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-digia-qt-preview"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-divx-open-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-divx-open-2.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-dl-de-by-1-0-de"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dl-de-by-1-0-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dl-de-by-2-0-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dl-de-by-nc-1-0-de"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-dl-de-by-nc-1-0-en"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-dmalloc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-do-no-harm-0.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-docbook"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dos32a-extender"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-doug-lea"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-douglas-young"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dpl-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-dr-john-maddock"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dropbear"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dropbear-2016"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dtree"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dual-bsd-gpl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dual-commercial-gpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-duende-sla-2022"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-dwtfnmfpl-3.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dynamic-drive-tou"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-dynarch-developer"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-dynarch-linkware"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ecfonts-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-eclipse-sua-2001"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2002"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2003"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2004"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2005"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2010"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2011"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2014"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2014-11"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-eclipse-sua-2017"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-ecma-documentation"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ecma-patent-coc-0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ecma-patent-coc-1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ecma-patent-coc-2"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ecosrh-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-efsl-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-egenix-1.0.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-egrappler"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ej-technologies-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ekioh"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-elastic-license-2018"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-elib-gpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ellis-lab"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-emit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-emx-library"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-energyplus-bsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-enhydra-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-epaperpress"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-epo-osl-2005.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-eric-glass"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-esri"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-esri-devkit"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-etalab-2.0-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-etalab-2.0-fr"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-examdiff"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-excelsior-jet-runtime"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-fabien-tassin"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fabric-agreement-2017"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-facebook-nuclide"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-facebook-patent-rights-2"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-facebook-software-license"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-fair-source-0.9"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-fancyzoom"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-fastbuild-2012-2020"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fatfs"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fftpack-2004"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-filament-group-mit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-first-works-appreciative-1.2"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-flex-2.5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-flex2sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-flora-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-flowplayer-gpl-3.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-font-alias"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-foobar2000"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-fpl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fplot"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fraunhofer-iso-14496-10"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-free-art-1.3"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-free-fork"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-free-unknown"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-freebsd-boot"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-freebsd-first"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-freemarker"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-freetts"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-freetype-patent"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-froala-owdl-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-frontier-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-fsf-notice"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-fsf-unlimited-no-warranty"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ftdi"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ftpbean"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-gareth-mccaughan"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-gary-s-brown"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-gcel-2022"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-gco-v3.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-gdcl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-generic-cla"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-generic-export-compliance"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-generic-tos"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-generic-trademark"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-genivia-gsoap"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-geoff-kuenning-1993"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ghostpdl-permissive"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ghostscript-1988"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-gitlab-ee"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-gladman-older-rijndael-code"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-glut"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-gnu-emacs-gpl-1988"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-goahead"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-good-boy"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-google-analytics-tos"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-analytics-tos-2015"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-analytics-tos-2016"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-analytics-tos-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-apis-tos-2021"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-cla"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-corporate-cla"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-maps-tos-2018-02-07"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-05-01"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-06-07"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-07-09"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-07-19"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-10-01"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2018-10-31"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2019-05-02"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2019-11-21"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2020-04-02"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2020-04-27"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-maps-tos-2020-05-06"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-ml-kit-tos-2022"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-patent-license"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-patent-license-fuchsia"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-patent-license-fuschia"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-patent-license-golang"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-patent-license-webm"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-patent-license-webrtc"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-google-playcore-sdk-tos-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-tos-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-tos-2014"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-tos-2017"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-tos-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-google-tos-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-gpl-2.0-adaptec"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-gpl-2.0-djvu"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-gpl-2.0-koterov"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-graphics-gems"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-greg-roelofs"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-gregory-pietsch"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-gsoap-1.3a"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-gust-font-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-gust-font-2006-09-30"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-gutenberg-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-h2-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-hacos-1.2"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-happy-bunny"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hauppauge-firmware-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hauppauge-firmware-oem"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hazelcast-community-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-hdf4"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hdf5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hdparm"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-helios-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-helix"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-here-disclaimer"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-here-proprietary"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-hessla"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hidapi"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hippocratic-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-hippocratic-1.1"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-hippocratic-1.2"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-hippocratic-2.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-historical-ntp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-historical-sell-variant"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-homebrewed"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hot-potato"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hp"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hp-enterprise-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hp-netperf"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-hp-proliant-essentials"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-hp-snmp-pp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hp-software-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hp-ux-java"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hp-ux-jre"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-hs-regexp-orig"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-html5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-httpget"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-hugo"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-hxd"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ian-kaplan"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ian-piumarta"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-as-is"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-data-server-2011"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ibm-developerworks-community"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ibm-dhcp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-icu"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-java-portlet-spec-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-jre"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ibm-nwsc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibm-sample"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ibpp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ic-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ic-shared-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-icann-public"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-icot-free"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-idt-notice"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ietf"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ietf-trust"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ilmid"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-imagen"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-indiana-extreme"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-infineon-free"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-1997-10"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2001-01"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2002-02"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2003-05"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2004-05"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2005-02"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2007-03"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-info-zip-2009-01"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-infonode-1.1"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-initial-developer-public"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-inner-net-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-inno-setup"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-installsite"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-intel"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-bcl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-bsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-intel-bsd-2-clause"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-intel-code-samples"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-confidential"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-intel-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-master-eula-sw-dev-2016"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-material"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-intel-mcu-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-microcode"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-osl-1989"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-intel-osl-1993"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-intel-royalty-free"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-intel-sample-source-code-2015"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-intel-scl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-iozone"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-iptc-2006"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-irfanview-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-iso-14496-10"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-iso-8879"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-iso-recorder"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-isotope-cla"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-issl-2018"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-itc-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-itu"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-itu-t"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-itu-t-gpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-itunes"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ja-sig"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jahia-1.3.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-jam-stapl"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-jamon"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-jason-mayes"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jasper-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-java-app-stub"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-java-research-1.5"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-java-research-1.6"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jboss-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jdbm-1.00"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jdom"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jelurida-public-1.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-jetbrains-purchase-terms"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-jetbrains-toolbox-oss-3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jetty"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jetty-ccla-1.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jgraph"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jgraph-general"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jide-sla"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-jj2000"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-jmagnetic"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-josl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-jpnic-mdnkit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jprs-oscl-1.1"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-jpython-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jquery-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-jrunner"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jscheme"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-jsfromhell"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-json-js-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-json-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-jsr-107-jcache-spec"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jsr-107-jcache-spec-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-jython"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-kalle-kaukonen"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-karl-peterson"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-katharos-0.1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-kde-accepted-gpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-kde-accepted-lgpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-keith-rule"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-kerberos"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-kevan-stannard"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-kevlin-henney"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-khronos"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-kreative-relay-fonts-free-1.2f"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-kumar-robotics"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-larabie"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lavantech"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-lcs-telegraphics"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ldap-sdk-free-use"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ldpc-1994"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpc-1997"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpc-1999"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpgpl-1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpgpl-1a"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpl-2.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-ldpm-1998"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-leap-motion-sdk-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lha"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-libcap"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-libgeotiff"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-libmib"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-libmng-2007"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-libpbm"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-librato-exception"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-libselinux-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-libsrv-1.0.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-libzip"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-license-file-reference"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-lil-1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-lilo"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-linotype-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-linum"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-linux-device-drivers"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-linuxbios"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-linuxhowtos"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-llgpl"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-llnl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-logica-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-lontium-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-losla"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-lsi-proprietary-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lucre"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-lumisoft-mail-server"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-luxi"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lyubinskiy-dropdown"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lyubinskiy-popup-window"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-lzma-sdk-2006"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-lzma-sdk-2008"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-lzma-sdk-original"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-lzma-sdk-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-madwifi-dual"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mame"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-manfred-klein-fonts-tos"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-mapbox-tos-2021"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-markus-kuhn-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-martin-birgmeier"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-marvell-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-marvell-firmware-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-matt-gallagher-attribution"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-matthew-kwan"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-matthew-welch-font-license"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-mattkruse"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-maxmind-geolite2-eula-2019"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-maxmind-odl"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-mcafee-tou"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mcrae-pl-4-r53"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mediainfo-lib"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-melange"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mentalis"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-merit-network-derivative"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-metageek-inssider-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-metrolink-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-mgopen-font-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-michael-barr"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-michigan-disclaimer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-microchip-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-microsoft-windows-rally-devkit"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mike95"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-minecraft-mod"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-minpack"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-1995"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-addition"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-license-1998"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-modification-obligations"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-nagy"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-no-advert-export-control"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-no-trademarks"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-old-style"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-old-style-sparse"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-readme"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-specification-disclaimer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-synopsys"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-taylor-variant"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-veillard-variant"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mit-xfig"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mod-dav-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-monetdb-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-motorola"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-moxa-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mozilla-gc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mozilla-ospl-1.0"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-mpeg-7"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mpeg-iso"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mpeg-ssg"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-asp-net-ajax-supp-terms"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-mvc3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-mvc4"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-mvc4-extensions"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-software"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-tools-pre-release"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-web-optimization"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-web-pages-2"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-asp-net-web-pages-templates"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-azure-data-studio"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-azure-spatialanchors-2.9.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-capicom"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-cl"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-ms-cla"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-ms-control-spy-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-data-tier-af-2022"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-dev-services-2018-06"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-dev-services-agreement"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-device-emulator-3.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-direct3d-d3d120n7-1.1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-directx-sdk-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-dxsdk-d3dx-9.29.952.3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-enterprise-library-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-entity-framework-4.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-entity-framework-5"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-eula-win-script-host"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-exchange-srv-2010-sp2-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-iis-container-eula-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-ilmerge"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-invisible-eula-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-jdbc-driver-40-sql-server"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-jdbc-driver-41-sql-server"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-jdbc-driver-60-sql-server"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-kinext-win-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-limited-community"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-limited-public"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-lpl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-msn-webgrease"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-framework-4-supp-terms"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-framework-deployment"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-net-library"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-library-2016-05"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-library-2018-11"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-library-2019-06"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-net-library-2020-09"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-nt-resource-kit"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-nuget"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-nuget-package-manager"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-office-extensible-file"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-office-system-programs-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-patent-promise"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-ms-patent-promise-mono"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-ms-permissive-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-platform-sdk"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-programsynthesis-7.22.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-python-vscode-pylance-2021"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-reactive-extensions-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-refl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-remote-ndis-usb-kit"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-research-shared-source"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-rsl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-silverlight-3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-sql-server-compact-4.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-sql-server-data-tools"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-sspl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-sysinternals-sla"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-testplatform-17.0.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-ttf-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-typescript-msbuild-4.1.4"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-2008-runtime"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-2010-runtime"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-2015-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-cpp-2015-runtime"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-studio-2017"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-visual-studio-2017-tools"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-visual-studio-code"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-studio-code-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-visual-studio-code-2022"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-vs-addons-ext-17.2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-web-developer-tools-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-win-container-eula-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-win-sdk-server-2008-net-3.5"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-windows-driver-kit"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-windows-identity-foundation"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-windows-os-2018"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-windows-sdk-win10"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ms-windows-sdk-win7-net-4"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-windows-server-2003-ddk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-windows-server-2003-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-ws-routing-spec"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ms-xamarin-uitest3.2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ms-xml-core-4.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-msj-sample-code"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-msntp"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-msppl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mtx-licensing-statement"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-mulanpsl-1.0-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mulanpsl-2.0-en"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mule-source-1.1.3"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-mule-source-1.1.4"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-mulle-kybernetik"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-mvt-1.1"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-mx4j"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-naughter"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ncbi"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-nero-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-netapp-sdk-aug2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-netcat"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-netcomponents"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-netron"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-netronome-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-network-time-protocol"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-new-relic"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-newlib-historical"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-newran"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-newton-king-cla"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-nexb-eula-saas-1.1.0"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-nexb-ssla-1.1.0"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-nice"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nicta-psl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-niels-ferguson"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nilsson-historical"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nist-srd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-no-license"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-node-js"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-non-violent-4.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nonexclusive"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nortel-dasa"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-northwoods-sla-2021"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-notre-dame"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nrl-permission"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ntlm"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ntpl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ntpl-origin"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-numerical-recipes-notice"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-nunit-v2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nvidia"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nvidia-2002"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nvidia-apex-sdk-eula-2011"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nvidia-cuda-supplement-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nvidia-gov"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nvidia-isaac-eula-2019.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nvidia-ngx-eula-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nvidia-sdk-eula-v0.11"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nvidia-video-codec-agreement"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nwhm"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nxp-firmware-patent"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nxp-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nxp-mc-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nxp-microctl-proprietary"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nxp-warranty-disclaimer"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-nysl-0.9982"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-nysl-0.9982-jp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-o-young-jong"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-oasis-ipr-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oasis-ipr-policy-2014"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oasis-ws-security-spec"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ocb-non-military-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ocb-open-source-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ocb-patent-openssl-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oclc-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-ocsl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-oculus-sdk"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-oculus-sdk-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oculus-sdk-3.5"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-odc-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-odl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-odmg"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ogc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ogc-2006"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ogc-document-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ogl-1.0a"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ogl-canada-2.0-fr"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ogl-wpd-3.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ohdl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-okl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-open-diameter"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-open-group"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-openi-pl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-openmap"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-openmarket-fastcgi"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-opennetcf-shared-source"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-openorb-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-openpbs-2.3"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-opensaml-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-openssl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-openvpn-as-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-opera-eula-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-opera-eula-eea-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-opera-widget-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-opl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-opml-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-opnl-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-opnl-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-oracle-bcl-java-platform-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-bcl-java-platform-2017"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-bcl-javaee"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-bcl-javase-javafx-2012"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-bcl-javase-javafx-2013"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-bcl-jsse-1.0.3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-code-samples-bsd"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-oracle-commercial-db-11g2"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-oracle-devtools-vsnet-dev"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-entitlement-05-15"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-java-ee-sdk-2010"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-master-agreement"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-oracle-nftc-2021"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-otn-javase-2019"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-sql-developer"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oracle-web-sites-tou"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oreilly-notice"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-osetpl-2.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-osf-1990"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-osgi-spec-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ossn-3.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-oswego-concurrent"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-other-copyleft"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-other-permissive"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-otn-dev-dist"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-dev-dist-2009"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-dev-dist-2014"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-dev-dist-2016"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-early-adopter-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-early-adopter-development"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-otn-standard-2014-09"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-owal-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-owf-cla-1.0-copyright"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-owf-cla-1.0-copyright-patent"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-owfa-1.0"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-owfa-1.0-patent-only"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-owtchart"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-oxygen-xml-webhelp-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ozplb-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ozplb-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paint-net"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-paolo-messina-2000"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paraview-1.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-passive-aggressive"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-patent-disclaimer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paul-hsieh-derivative"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-paul-hsieh-exposition"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-paul-mackerras"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paul-mackerras-binary"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paul-mackerras-new"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paul-mackerras-simplified"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paulo-soares"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-paypal-sdk-2013-2016"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pbl-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-pcre"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pd-mit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pd-programming"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pdf-creator-pilot"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-pdl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-perl-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-peter-deutsch-document"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pfe-proprietary-notice"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-pftijah-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-pftus-1.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-phil-bunce"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-philippe-de-muyter"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-philips-proprietary-notice2000"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-phorum-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-php-2.0.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pine"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pivotal-tou"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-pixabay-content"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-planet-source-code"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-pml-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-pngsuite"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-politepix-pl-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-polyform-defensive-1.0.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-polyform-free-trial-1.0.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-polyform-internal-use-1.0.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-polyform-perimeter-1.0.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-polyform-shield-1.0.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-polyform-strict-1.0.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-powervr-tools-software-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ppp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-proprietary"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-proprietary-license"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-prosperity-1.0.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-prosperity-2.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-prosperity-3.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-protobuf"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-psf-3.7.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-psytec-freesoft"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-public-domain"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-public-domain-disclaimer"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-purdue-bsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pybench"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pycrypto"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-pygres-2.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-python-cwi"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-qaplug"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-qca-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-qca-technology"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-qlogic-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-qlogic-microcode"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-qpopper"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-qt-commercial-1.1"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-qti-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-qualcomm-iso"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-qualcomm-turing"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-quickfix-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-quicktime"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-quin-street"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-quirksmode"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-qwt-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-rackspace"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-radvd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ralf-corsepius"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ralink-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-rar-winrar-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-rcsl-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-rcsl-3.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-realm-platform-extension-2017"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-red-hat-attribution"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-red-hat-bsd-simplified"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-red-hat-logos"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-red-hat-trademarks"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-redis-source-available-1.0"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-reportbug"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rh-eula"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-rh-eula-lgpl"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-ricebsd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-richard-black"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-riverbank-sip"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-robert-hubley"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rogue-wave"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-rsa-1990"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rsa-cryptoki"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rsa-demo"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rsa-md2"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-rsa-md4"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rsa-proprietary"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-rtools-util"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-rubyencoder-commercial"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-rubyencoder-loader"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-rute"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ryszard-szopa"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-saas-mit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-saf"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-safecopy-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-san-francisco-font"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sandeep"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sash"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sata"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sbia-b"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-scancode-acknowledgment"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-scanlogd-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-scansoft-1.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-scilab-en"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scilab-fr"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scintilla"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-scola-en"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scola-fr"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scribbles"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-script-asylum"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-script-nikhilk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scrub"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-scsl-3.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-secret-labs-2011"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-see-license"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-sencha-commercial"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-sencha-commercial-3.17"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-sencha-commercial-3.9"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-service-comp-arch"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sgi-cid-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sgi-glx-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sglib"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-shavlik-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-shital-shah"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-simpl-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-slf4j-2005"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-slf4j-2008"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-slysoft-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-smail-gpl"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-smartlabs-freeware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-snmp4j-smi"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-snprintf"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-softerra-ldap-browser-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-softfloat"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-softfloat-2.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-softsurfer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-solace-software-eula-2020"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-spark-jive"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sparky"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-speechworks-1.1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-splunk-3pp-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-splunk-mint-tos-2018"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-splunk-sla"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-square-cla"
+  categories:
+  - "patent-license"
+- id: "LicenseRef-scancode-squeak"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-srgb"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ssleay"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ssleay-windows"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-st-bsd-restricted"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-st-mcd-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-stanford-mrouted"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-stanford-pvrg"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-statewizard"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-stax"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-stlport-2000"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-stlport-4.5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-stmicro-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-stmicroelectronics-centrallabs"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-stream-benchmark"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-stu-nicholls"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sun-bcl-11-06"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-11-07"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-11-08"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.2.x"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.4.2"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.4.x"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-j2re-5.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-java-servlet-imp-2.1.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-javahelp"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-jimi-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-jre6"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-jsmq"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-opendmk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-openjdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-sdk-1.3"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-sdk-1.4.2"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-sdk-5.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-sdk-6.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bcl-web-start"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-bsd-extra"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-sun-communications-api"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-ejb-spec-2.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-ejb-spec-3.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-entitlement-03-15"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-entitlement-jaf"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-glassfish"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-iiop"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-java-transaction-api"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-java-web-services-dev-1.6"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-javamail"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-jsr-spec-04-2006"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-jta-spec-1.0.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-jta-spec-1.0.1b"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-no-high-risk-activities"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-sun-project-x"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-prop-non-commercial"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-proprietary-jdk"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-sun-rpc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sun-sdk-spec-1.1"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-sun-sissl-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-sun-source"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sun-ssscfr-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-sunpro"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sunsoft"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-supervisor"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-sustainable-use-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-svndiff"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-swig"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-symphonysoft"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-synopsys-attribution"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-synopsys-mit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-synthesis-toolkit"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-takao-abe"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-takuya-ooura"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-taligent-jdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.2"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.3"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-tanuki-development"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-tanuki-maintenance"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-teamdev-services"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-tekhvc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-telerik-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-tenable-nessus"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-term-readkey"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tested-software"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tex-live"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tfl"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-tgppl-1.0"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-things-i-made-public-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-thomas-bandt"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-thor-pl"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-ti-broadband-apps"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ti-linux-firmware"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ti-restricted"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-tiger-crypto"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tigra-calendar-3.2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tigra-calendar-4.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tim-janik-2003"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-timestamp-picker"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tizen-sdk"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-tpl-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-trademark-notice"
+  categories:
+  - "unstated-license"
+- id: "LicenseRef-scancode-trca-odl-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-treeview-developer"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-treeview-distributor"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-triptracker"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-truecrypt-3.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-tsl-2018"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-tsl-2020"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-tso-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ttcl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ttf2pt1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ttyp0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-tumbolia"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-twisted-snmp"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-txl-10.5"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-ubc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ubuntu-font-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-unbuntu-font-1.0"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-unicode"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-unicode-data-software"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-unicode-icu-58"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-unicode-mappings"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-unknown"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-unknown-license-reference"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-unknown-spdx"
+  categories:
+  - "unknown"
+- id: "LicenseRef-scancode-unpbook"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-unpublished-source"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-unrar"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-unsplash"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-uofu-rfpl"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-us-govt-public-domain"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-us-govt-unlimited-rights"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-usrobotics-permissive"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-utopia"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-vbaccelerator"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-vcalendar"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-verisign"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-vhfpl-1.1"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-vic-metcalfe-pd"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-vicomsoft-software"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-visual-idiot"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-visual-numerics"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-vita-nuova-liberal"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-vitesse-prop"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-vixie-cron"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-vnc-viewer-ios"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-volatility-vsl-v1.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-vpl-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-vpl-1.2"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-vs10x-code-map"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-vuforia-2013-07-29"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-w3c-docs-19990405"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-w3c-docs-20021231"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-w3c-documentation"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-w3c-software-20021231"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-w3c-test-suite"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-warranty-disclaimer"
+  categories:
+  - "generic"
+- id: "LicenseRef-scancode-waterfall-feed-parser"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-westhawk"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-whistle"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-whitecat"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wide-license"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wifi-alliance"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-william-alexander"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wince-50-shared-source"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-windriver-commercial"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-wingo"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wink"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-winzip-eula"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-winzip-self-extractor"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-wol"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wordnet"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wrox"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wrox-download"
+  categories:
+  - "source-available"
+- id: "LicenseRef-scancode-ws-addressing-spec"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ws-policy-specification"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-ws-trust-specification"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wtfnmfpl-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wtfpl-1.0"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-wthpl-1.0"
+  categories:
+  - "public-domain"
+- id: "LicenseRef-scancode-wxwidgets"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-wxwindows-r-3.0"
+  categories:
+  - "copyleft-limited"
+- id: "LicenseRef-scancode-wxwindows-u-3.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-acer"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-adobe"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-adobe-dec"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-bitstream"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-dec1"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-dec2"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-doc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-dsc"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-hanson"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-ibm"
+  categories:
+  - "copyleft"
+- id: "LicenseRef-scancode-x11-lucent"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-lucent-variant"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-oar"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-opengl"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-quarterdeck"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-r75"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-realmode"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-sg"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-stanford"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-tektronix"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-x11r5"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11-xconsortium-veillard"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-x11r5-authors"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-xceed-community-2021"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-xfree86-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-xilinx-2016"
+  categories:
+  - "free-restricted"
+- id: "LicenseRef-scancode-xming"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-xmldb-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-xxd"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-yahoo-browserplus-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-yahoo-messenger-eula"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-yale-cas"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-yensdesign"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-yolo-1.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-yolo-2.0"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-zapatec-calendar"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-zeusbench"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-zhorn-stickies"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-zipeg"
+  categories:
+  - "proprietary-free"
+- id: "LicenseRef-scancode-ziplist5-geocode-dup-addendum"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ziplist5-geocode-enterprise"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-ziplist5-geocode-workstation"
+  categories:
+  - "commercial"
+- id: "LicenseRef-scancode-zpl-1.0"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-zsh"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-zuora-software"
+  categories:
+  - "permissive"
+- id: "LicenseRef-scancode-zveno-research"
+  categories:
+  - "permissive"
+- id: "Linux-OpenIB"
+  categories:
+  - "permissive"
+- id: "Linux-man-pages-copyleft"
+  categories:
+  - "copyleft"
 - id: "MIT"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "MIT-0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "MIT-advertising"
-  categories:
-  - "permissive"
-  - "include-in-notice-file"
 - id: "MIT-CMU"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "MIT-Modern-Variant"
+  categories:
+  - "permissive"
+- id: "MIT-advertising"
+  categories:
+  - "permissive"
 - id: "MIT-enna"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "MIT-feh"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "MIT-open-group"
+  categories:
+  - "permissive"
 - id: "MITNFA"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "MPL-1.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "MPL-1.1"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "MPL-2.0"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
+- id: "MPL-2.0-no-copyleft-exception"
+  categories:
+  - "copyleft-limited"
 - id: "MS-PL"
   categories:
   - "permissive"
-  - "include-in-notice-file"
 - id: "MS-RL"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
+- id: "MTLL"
+  categories:
+  - "permissive"
+- id: "MakeIndex"
+  categories:
+  - "copyleft"
+- id: "MirOS"
+  categories:
+  - "permissive"
+- id: "Motosoto"
+  categories:
+  - "copyleft"
+- id: "MulanPSL-1.0"
+  categories:
+  - "permissive"
+- id: "MulanPSL-2.0"
+  categories:
+  - "permissive"
+- id: "Multics"
+  categories:
+  - "permissive"
+- id: "Mup"
+  categories:
+  - "permissive"
+- id: "NAIST-2003"
+  categories:
+  - "permissive"
+- id: "NASA-1.3"
+  categories:
+  - "copyleft-limited"
+- id: "NBPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "NCGL-UK-2.0"
+  categories:
+  - "free-restricted"
+- id: "NCSA"
+  categories:
+  - "permissive"
+- id: "NGPL"
+  categories:
+  - "copyleft-limited"
+- id: "NIST-PD"
+  categories:
+  - "public-domain"
+- id: "NIST-PD-fallback"
+  categories:
+  - "permissive"
+- id: "NLOD-1.0"
+  categories:
+  - "permissive"
+- id: "NLOD-2.0"
+  categories:
+  - "permissive"
+- id: "NLPL"
+  categories:
+  - "public-domain"
+- id: "NOSL"
+  categories:
+  - "copyleft-limited"
+- id: "NPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "NPL-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "NPOSL-3.0"
+  categories:
+  - "copyleft"
+- id: "NRL"
+  categories:
+  - "permissive"
+- id: "NTP"
+  categories:
+  - "permissive"
+- id: "NTP-0"
+  categories:
+  - "permissive"
+- id: "Naumen"
+  categories:
+  - "permissive"
+- id: "Net-SNMP"
+  categories:
+  - "permissive"
+- id: "NetCDF"
+  categories:
+  - "permissive"
+- id: "Newsletr"
+  categories:
+  - "permissive"
+- id: "Nokia"
+  categories:
+  - "copyleft-limited"
+- id: "Noweb"
+  categories:
+  - "copyleft-limited"
+- id: "O-UDA-1.0"
+  categories:
+  - "permissive"
+- id: "OCCT-PL"
+  categories:
+  - "copyleft-limited"
+- id: "OCLC-2.0"
+  categories:
+  - "copyleft-limited"
+- id: "ODC-By-1.0"
+  categories:
+  - "permissive"
 - id: "ODbL-1.0"
   categories:
   - "copyleft"
-  - "include-in-notice-file"
 - id: "OFL-1.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "OFL-1.0-RFN"
+  categories:
+  - "permissive"
+- id: "OFL-1.0-no-RFN"
+  categories:
+  - "permissive"
 - id: "OFL-1.1"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "OFL-1.1-RFN"
+  categories:
+  - "permissive"
+- id: "OFL-1.1-no-RFN"
+  categories:
+  - "permissive"
+- id: "OGC-1.0"
+  categories:
+  - "permissive"
+- id: "OGDL-Taiwan-1.0"
+  categories:
+  - "permissive"
+- id: "OGL-Canada-2.0"
+  categories:
+  - "permissive"
+- id: "OGL-UK-1.0"
+  categories:
+  - "permissive"
+- id: "OGL-UK-2.0"
+  categories:
+  - "permissive"
+- id: "OGL-UK-3.0"
+  categories:
+  - "permissive"
+- id: "OGTSL"
+  categories:
+  - "copyleft-limited"
+- id: "OLDAP-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "OLDAP-1.2"
+  categories:
+  - "copyleft-limited"
+- id: "OLDAP-1.3"
+  categories:
+  - "copyleft-limited"
+- id: "OLDAP-1.4"
+  categories:
+  - "copyleft-limited"
+- id: "OLDAP-2.0"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.0.1"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.1"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.2"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.2.1"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.2.2"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.3"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.4"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.5"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.6"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.7"
+  categories:
+  - "permissive"
+- id: "OLDAP-2.8"
+  categories:
+  - "permissive"
+- id: "OML"
+  categories:
+  - "permissive"
+- id: "OPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "OPUBL-1.0"
+  categories:
+  - "permissive"
+- id: "OSET-PL-2.1"
+  categories:
+  - "copyleft-limited"
+- id: "OSL-1.0"
+  categories:
+  - "copyleft"
+- id: "OSL-1.1"
+  categories:
+  - "copyleft"
+- id: "OSL-2.0"
+  categories:
+  - "copyleft"
+- id: "OSL-2.1"
+  categories:
+  - "copyleft"
+- id: "OSL-3.0"
+  categories:
+  - "copyleft"
 - id: "OpenSSL"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "PSF"
+- id: "PDDL-1.0"
   categories:
-  - "strong-copyleft"
-  - "include-in-notice-file"
+  - "public-domain"
+- id: "PHP-3.0"
+  categories:
+  - "permissive"
+- id: "PHP-3.01"
+  categories:
+  - "permissive"
+- id: "PSF-2.0"
+  categories:
+  - "permissive"
+- id: "Parity-6.0.0"
+  categories:
+  - "copyleft"
+- id: "Parity-7.0.0"
+  categories:
+  - "copyleft"
+- id: "Plexus"
+  categories:
+  - "permissive"
+- id: "PolyForm-Noncommercial-1.0.0"
+  categories:
+  - "source-available"
+- id: "PolyForm-Small-Business-1.0.0"
+  categories:
+  - "source-available"
+- id: "PostgreSQL"
+  categories:
+  - "permissive"
 - id: "Python-2.0"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "QPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "Qhull"
+  categories:
+  - "copyleft-limited"
+- id: "RHeCos-1.1"
+  categories:
+  - "copyleft"
+- id: "RPL-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "RPL-1.5"
+  categories:
+  - "copyleft-limited"
+- id: "RPSL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "RSA-MD"
+  categories:
+  - "permissive"
+- id: "RSCPL"
+  categories:
+  - "copyleft-limited"
+- id: "Rdisc"
+  categories:
+  - "permissive"
 - id: "Ruby"
   categories:
   - "copyleft-limited"
-  - "include-in-notice-file"
 - id: "SAX-PD"
   categories:
   - "public-domain"
-  - "include-in-notice-file"
+- id: "SCEA"
+  categories:
+  - "permissive"
+- id: "SGI-B-1.0"
+  categories:
+  - "free-restricted"
+- id: "SGI-B-1.1"
+  categories:
+  - "permissive"
+- id: "SGI-B-2.0"
+  categories:
+  - "permissive"
+- id: "SHL-0.5"
+  categories:
+  - "permissive"
+- id: "SHL-0.51"
+  categories:
+  - "permissive"
+- id: "SISSL"
+  categories:
+  - "proprietary-free"
+- id: "SISSL-1.2"
+  categories:
+  - "proprietary-free"
+- id: "SMLNJ"
+  categories:
+  - "permissive"
+- id: "SMPPL"
+  categories:
+  - "copyleft-limited"
+- id: "SNIA"
+  categories:
+  - "copyleft"
+- id: "SPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "SSH-OpenSSH"
+  categories:
+  - "permissive"
+- id: "SSH-short"
+  categories:
+  - "permissive"
+- id: "SSPL-1.0"
+  categories:
+  - "source-available"
+- id: "SWL"
+  categories:
+  - "permissive"
+- id: "Saxpath"
+  categories:
+  - "permissive"
+- id: "SchemeReport"
+  categories:
+  - "permissive"
+- id: "Sendmail"
+  categories:
+  - "permissive"
+- id: "Sendmail-8.23"
+  categories:
+  - "copyleft-limited"
+- id: "SimPL-2.0"
+  categories:
+  - "copyleft"
+- id: "Sleepycat"
+  categories:
+  - "copyleft"
+- id: "Spencer-86"
+  categories:
+  - "permissive"
+- id: "Spencer-94"
+  categories:
+  - "permissive"
+- id: "Spencer-99"
+  categories:
+  - "permissive"
+- id: "SugarCRM-1.1.3"
+  categories:
+  - "copyleft"
+- id: "TAPR-OHL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "TCL"
+  categories:
+  - "permissive"
+- id: "TCP-wrappers"
+  categories:
+  - "permissive"
+- id: "TMate"
+  categories:
+  - "copyleft"
+- id: "TORQUE-1.1"
+  categories:
+  - "copyleft-limited"
+- id: "TOSL"
+  categories:
+  - "copyleft"
+- id: "TU-Berlin-1.0"
+  categories:
+  - "permissive"
+- id: "TU-Berlin-2.0"
+  categories:
+  - "permissive"
+- id: "UCL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "UPL-1.0"
+  categories:
+  - "permissive"
+- id: "Unicode-DFS-2015"
+  categories:
+  - "permissive"
+- id: "Unicode-DFS-2016"
+  categories:
+  - "permissive"
+- id: "Unicode-TOU"
+  categories:
+  - "proprietary-free"
 - id: "Unlicense"
   categories:
   - "public-domain"
-  - "include-in-notice-file"
+- id: "VOSTROM"
+  categories:
+  - "copyleft"
+- id: "VSL-1.0"
+  categories:
+  - "permissive"
+- id: "Vim"
+  categories:
+  - "copyleft"
 - id: "W3C"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "WTFPL"
+- id: "W3C-19980720"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "W3C-20150513"
+  categories:
+  - "permissive"
+- id: "WTFPL"
+  categories:
+  - "public-domain"
+- id: "Watcom-1.0"
+  categories:
+  - "proprietary-free"
+- id: "Wsuipa"
+  categories:
+  - "permissive"
 - id: "X11"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "X11-distribute-modifications-variant"
+  categories:
+  - "permissive"
+- id: "XFree86-1.1"
+  categories:
+  - "permissive"
+- id: "XSkat"
+  categories:
+  - "permissive"
+- id: "Xerox"
+  categories:
+  - "permissive"
+- id: "Xnet"
+  categories:
+  - "permissive"
+- id: "YPL-1.0"
+  categories:
+  - "copyleft-limited"
+- id: "YPL-1.1"
+  categories:
+  - "copyleft"
+- id: "ZPL-1.1"
+  categories:
+  - "permissive"
+- id: "ZPL-2.0"
+  categories:
+  - "permissive"
+- id: "ZPL-2.1"
+  categories:
+  - "permissive"
+- id: "Zed"
+  categories:
+  - "permissive"
+- id: "Zend-2.0"
+  categories:
+  - "permissive"
+- id: "Zimbra-1.3"
+  categories:
+  - "copyleft-limited"
+- id: "Zimbra-1.4"
+  categories:
+  - "copyleft-limited"
 - id: "Zlib"
   categories:
   - "permissive"
-  - "include-in-notice-file"
-- id: "bzip2-1.0.5"
+- id: "blessing"
   categories:
-  - "permissive"
-  - "include-in-notice-file"
+  - "public-domain"
 - id: "bzip2-1.0.6"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "copyleft-next-0.3.0"
+  categories:
+  - "copyleft"
+- id: "copyleft-next-0.3.1"
+  categories:
+  - "copyleft"
 - id: "curl"
   categories:
   - "permissive"
-  - "include-in-notice-file"
+- id: "diffmark"
+  categories:
+  - "public-domain"
+- id: "dvipdfm"
+  categories:
+  - "permissive"
+- id: "eGenix"
+  categories:
+  - "permissive"
+- id: "etalab-2.0"
+  categories:
+  - "permissive"
+- id: "gSOAP-1.3b"
+  categories:
+  - "copyleft-limited"
+- id: "gnuplot"
+  categories:
+  - "copyleft-limited"
+- id: "iMatix"
+  categories:
+  - "permissive"
+- id: "libpng-2.0"
+  categories:
+  - "permissive"
+- id: "libselinux-1.0"
+  categories:
+  - "public-domain"
+- id: "libtiff"
+  categories:
+  - "permissive"
+- id: "mpich2"
+  categories:
+  - "permissive"
+- id: "mplus"
+  categories:
+  - "permissive"
+- id: "psfrag"
+  categories:
+  - "permissive"
+- id: "psutils"
+  categories:
+  - "permissive"
+- id: "wxWindows"
+  categories:
+  - "copyleft-limited"
+- id: "xinetd"
+  categories:
+  - "permissive"
+- id: "xpp"
+  categories:
+  - "permissive"
+- id: "zlib-acknowledgement"
+  categories:
+  - "permissive"
+category_names:
+- "commercial"
+- "copyleft"
+- "copyleft-limited"
+- "free-restricted"
+- "generic"
+- "patent-license"
+- "permissive"
+- "proprietary-free"
+- "public-domain"
+- "source-available"
+- "unknown"
+- "unstated-license"
+licenses_by_category:
+  permissive:
+  - "0BSD"
+  - "AAL"
+  - "ADSL"
+  - "AFL-1.1"
+  - "AFL-1.2"
+  - "AFL-2.0"
+  - "AFL-2.1"
+  - "AFL-3.0"
+  - "AMDPLPA"
+  - "AML"
+  - "AMPAS"
+  - "ANTLR-PD"
+  - "APAFML"
+  - "Abstyles"
+  - "Adobe-2006"
+  - "Adobe-Glyph"
+  - "Afmparse"
+  - "Apache-1.0"
+  - "Apache-1.1"
+  - "Apache-2.0"
+  - "App-s2p"
+  - "BSD-1-Clause"
+  - "BSD-2-Clause"
+  - "BSD-2-Clause-Patent"
+  - "BSD-2-Clause-Views"
+  - "BSD-3-Clause"
+  - "BSD-3-Clause-Attribution"
+  - "BSD-3-Clause-Clear"
+  - "BSD-3-Clause-LBNL"
+  - "BSD-3-Clause-Modification"
+  - "BSD-3-Clause-Open-MPI"
+  - "BSD-4-Clause"
+  - "BSD-4-Clause-Shortened"
+  - "BSD-4-Clause-UC"
+  - "BSD-Source-Code"
+  - "BSL-1.0"
+  - "Baekmuk"
+  - "Bahyph"
+  - "Barr"
+  - "Beerware"
+  - "Bitstream-Vera"
+  - "BlueOak-1.0.0"
+  - "Borceux"
+  - "CC-BY-1.0"
+  - "CC-BY-2.0"
+  - "CC-BY-2.5"
+  - "CC-BY-2.5-AU"
+  - "CC-BY-3.0"
+  - "CC-BY-3.0-AT"
+  - "CC-BY-3.0-DE"
+  - "CC-BY-3.0-NL"
+  - "CC-BY-3.0-US"
+  - "CC-BY-4.0"
+  - "CDLA-Permissive-1.0"
+  - "CDLA-Permissive-2.0"
+  - "CECILL-B"
+  - "CERN-OHL-1.1"
+  - "CERN-OHL-1.2"
+  - "CERN-OHL-P-2.0"
+  - "CNRI-Jython"
+  - "CNRI-Python"
+  - "CNRI-Python-GPL-Compatible"
+  - "COIL-1.0"
+  - "Caldera"
+  - "Community-Spec-1.0"
+  - "Condor-1.1"
+  - "Crossword"
+  - "CrystalStacker"
+  - "Cube"
+  - "DL-DE-BY-2.0"
+  - "DOC"
+  - "DRL-1.0"
+  - "DSDP"
+  - "Dotseqn"
+  - "ECL-1.0"
+  - "ECL-2.0"
+  - "EFL-1.0"
+  - "EFL-2.0"
+  - "EPICS"
+  - "EUDatagrid"
+  - "Entessa"
+  - "FSFAP"
+  - "FSFULLR"
+  - "FTL"
+  - "Fair"
+  - "FreeBSD-DOC"
+  - "GD"
+  - "GLWTPL"
+  - "Giftware"
+  - "Glulxe"
+  - "HPND"
+  - "HPND-sell-variant"
+  - "HTMLTIDY"
+  - "HaskellReport"
+  - "IBM-pibs"
+  - "ICU"
+  - "IJG"
+  - "ISC"
+  - "ImageMagick"
+  - "Info-ZIP"
+  - "Intel"
+  - "Intel-ACPI"
+  - "JPNIC"
+  - "JSON"
+  - "Jam"
+  - "JasPer-2.0"
+  - "Latex2e"
+  - "Leptonica"
+  - "Libpng"
+  - "LicenseRef-scancode-3com-microcode"
+  - "LicenseRef-scancode-3dslicer-1.0"
+  - "LicenseRef-scancode-4suite-1.1"
+  - "LicenseRef-scancode-accellera-systemc"
+  - "LicenseRef-scancode-adi-bsd"
+  - "LicenseRef-scancode-adrian"
+  - "LicenseRef-scancode-agere-bsd"
+  - "LicenseRef-scancode-aladdin-md5"
+  - "LicenseRef-scancode-alexisisaac-freeware"
+  - "LicenseRef-scancode-amd-historical"
+  - "LicenseRef-scancode-ams-fonts"
+  - "LicenseRef-scancode-anu-license"
+  - "LicenseRef-scancode-apache-due-credit"
+  - "LicenseRef-scancode-apple-attribution"
+  - "LicenseRef-scancode-apple-attribution-1997"
+  - "LicenseRef-scancode-apple-excl"
+  - "LicenseRef-scancode-apple-sscl"
+  - "LicenseRef-scancode-aravindan-premkumar"
+  - "LicenseRef-scancode-argouml"
+  - "LicenseRef-scancode-arm-llvm-sga"
+  - "LicenseRef-scancode-array-input-method-pl"
+  - "LicenseRef-scancode-asmus"
+  - "LicenseRef-scancode-asn1"
+  - "LicenseRef-scancode-atkinson-hyperlegible-font"
+  - "LicenseRef-scancode-bakoma-fonts-1995"
+  - "LicenseRef-scancode-bea-2.1"
+  - "LicenseRef-scancode-beal-screamer"
+  - "LicenseRef-scancode-bigdigits"
+  - "LicenseRef-scancode-bigelow-holmes"
+  - "LicenseRef-scancode-biopython"
+  - "LicenseRef-scancode-bitzi-pd"
+  - "LicenseRef-scancode-blas-2017"
+  - "LicenseRef-scancode-bohl-0.2"
+  - "LicenseRef-scancode-boost-original"
+  - "LicenseRef-scancode-bpmn-io"
+  - "LicenseRef-scancode-brent-corkum"
+  - "LicenseRef-scancode-brian-clapper"
+  - "LicenseRef-scancode-brian-gladman"
+  - "LicenseRef-scancode-brian-gladman-3-clause"
+  - "LicenseRef-scancode-brian-gladman-dual"
+  - "LicenseRef-scancode-broadcom-cfe"
+  - "LicenseRef-scancode-broadcom-linux-timer"
+  - "LicenseRef-scancode-brocade-firmware"
+  - "LicenseRef-scancode-bruno-podetti"
+  - "LicenseRef-scancode-bsd-1-clause-build"
+  - "LicenseRef-scancode-bsd-1988"
+  - "LicenseRef-scancode-bsd-2-clause-freebsd"
+  - "LicenseRef-scancode-bsd-2-clause-netbsd"
+  - "LicenseRef-scancode-bsd-2-clause-plus-advertizing"
+  - "LicenseRef-scancode-bsd-3-clause-devine"
+  - "LicenseRef-scancode-bsd-3-clause-fda"
+  - "LicenseRef-scancode-bsd-3-clause-jtag"
+  - "LicenseRef-scancode-bsd-3-clause-no-change"
+  - "LicenseRef-scancode-bsd-3-clause-no-trademark"
+  - "LicenseRef-scancode-bsd-3-clause-sun"
+  - "LicenseRef-scancode-bsd-ack-carrot2"
+  - "LicenseRef-scancode-bsd-artwork"
+  - "LicenseRef-scancode-bsd-atmel"
+  - "LicenseRef-scancode-bsd-axis"
+  - "LicenseRef-scancode-bsd-axis-nomod"
+  - "LicenseRef-scancode-bsd-credit"
+  - "LicenseRef-scancode-bsd-dpt"
+  - "LicenseRef-scancode-bsd-export"
+  - "LicenseRef-scancode-bsd-innosys"
+  - "LicenseRef-scancode-bsd-intel"
+  - "LicenseRef-scancode-bsd-mylex"
+  - "LicenseRef-scancode-bsd-new-derivative"
+  - "LicenseRef-scancode-bsd-new-nomod"
+  - "LicenseRef-scancode-bsd-new-tcpdump"
+  - "LicenseRef-scancode-bsd-no-disclaimer"
+  - "LicenseRef-scancode-bsd-no-disclaimer-unmodified"
+  - "LicenseRef-scancode-bsd-original-muscle"
+  - "LicenseRef-scancode-bsd-original-uc-1986"
+  - "LicenseRef-scancode-bsd-original-uc-1990"
+  - "LicenseRef-scancode-bsd-original-voices"
+  - "LicenseRef-scancode-bsd-plus-mod-notice"
+  - "LicenseRef-scancode-bsd-simplified-darwin"
+  - "LicenseRef-scancode-bsd-simplified-intel"
+  - "LicenseRef-scancode-bsd-simplified-source"
+  - "LicenseRef-scancode-bsd-top"
+  - "LicenseRef-scancode-bsd-top-gpl-addition"
+  - "LicenseRef-scancode-bsd-unchanged"
+  - "LicenseRef-scancode-bsd-unmodified"
+  - "LicenseRef-scancode-bsd-x11"
+  - "LicenseRef-scancode-bsla"
+  - "LicenseRef-scancode-bsla-no-advert"
+  - "LicenseRef-scancode-bytemark"
+  - "LicenseRef-scancode-bzip2-libbzip-1.0.5"
+  - "LicenseRef-scancode-can-ogl-alberta-2.1"
+  - "LicenseRef-scancode-can-ogl-british-columbia-2.0"
+  - "LicenseRef-scancode-can-ogl-nova-scotia-1.0"
+  - "LicenseRef-scancode-can-ogl-ontario-1.0"
+  - "LicenseRef-scancode-can-ogl-toronto-1.0"
+  - "LicenseRef-scancode-careware"
+  - "LicenseRef-scancode-carnegie-mellon"
+  - "LicenseRef-scancode-carnegie-mellon-contributors"
+  - "LicenseRef-scancode-cavium-malloc"
+  - "LicenseRef-scancode-cc-by-2.0-uk"
+  - "LicenseRef-scancode-cecill-b-en"
+  - "LicenseRef-scancode-cern-attribution-1995"
+  - "LicenseRef-scancode-cgic"
+  - "LicenseRef-scancode-chicken-dl-0.2"
+  - "LicenseRef-scancode-chris-maunder"
+  - "LicenseRef-scancode-chris-stoy"
+  - "LicenseRef-scancode-classic-vb"
+  - "LicenseRef-scancode-classworlds"
+  - "LicenseRef-scancode-clear-bsd-1-clause"
+  - "LicenseRef-scancode-click-license"
+  - "LicenseRef-scancode-cmr-no"
+  - "LicenseRef-scancode-cmu-computing-services"
+  - "LicenseRef-scancode-cmu-mit"
+  - "LicenseRef-scancode-cmu-simple"
+  - "LicenseRef-scancode-cmu-template"
+  - "LicenseRef-scancode-code-credit-license-1.0.1"
+  - "LicenseRef-scancode-codeguru-permissions"
+  - "LicenseRef-scancode-codesourcery-2004"
+  - "LicenseRef-scancode-commonj-timer"
+  - "LicenseRef-scancode-compass"
+  - "LicenseRef-scancode-componentace-jcraft"
+  - "LicenseRef-scancode-cosl"
+  - "LicenseRef-scancode-cpm-2022"
+  - "LicenseRef-scancode-cpp-core-guidelines"
+  - "LicenseRef-scancode-crcalc"
+  - "LicenseRef-scancode-cryptopp"
+  - "LicenseRef-scancode-csprng"
+  - "LicenseRef-scancode-cve-tou"
+  - "LicenseRef-scancode-cwe-tou"
+  - "LicenseRef-scancode-cximage"
+  - "LicenseRef-scancode-d-zlib"
+  - "LicenseRef-scancode-damail"
+  - "LicenseRef-scancode-dante-treglia"
+  - "LicenseRef-scancode-datamekanix-license"
+  - "LicenseRef-scancode-dbad-1.1"
+  - "LicenseRef-scancode-dco-1.1"
+  - "LicenseRef-scancode-dejavu-font"
+  - "LicenseRef-scancode-delorie-historical"
+  - "LicenseRef-scancode-dhtmlab-public"
+  - "LicenseRef-scancode-dl-de-by-1-0-de"
+  - "LicenseRef-scancode-dl-de-by-1-0-en"
+  - "LicenseRef-scancode-dl-de-by-2-0-en"
+  - "LicenseRef-scancode-dmalloc"
+  - "LicenseRef-scancode-docbook"
+  - "LicenseRef-scancode-dos32a-extender"
+  - "LicenseRef-scancode-douglas-young"
+  - "LicenseRef-scancode-dr-john-maddock"
+  - "LicenseRef-scancode-dropbear"
+  - "LicenseRef-scancode-dropbear-2016"
+  - "LicenseRef-scancode-dtree"
+  - "LicenseRef-scancode-dual-bsd-gpl"
+  - "LicenseRef-scancode-dwtfnmfpl-3.0"
+  - "LicenseRef-scancode-dynamic-drive-tou"
+  - "LicenseRef-scancode-ecfonts-1.0"
+  - "LicenseRef-scancode-egenix-1.0.0"
+  - "LicenseRef-scancode-ekioh"
+  - "LicenseRef-scancode-ellis-lab"
+  - "LicenseRef-scancode-emit"
+  - "LicenseRef-scancode-emx-library"
+  - "LicenseRef-scancode-energyplus-bsd"
+  - "LicenseRef-scancode-epaperpress"
+  - "LicenseRef-scancode-eric-glass"
+  - "LicenseRef-scancode-etalab-2.0-en"
+  - "LicenseRef-scancode-fabien-tassin"
+  - "LicenseRef-scancode-fastbuild-2012-2020"
+  - "LicenseRef-scancode-fatfs"
+  - "LicenseRef-scancode-fftpack-2004"
+  - "LicenseRef-scancode-filament-group-mit"
+  - "LicenseRef-scancode-flex-2.5"
+  - "LicenseRef-scancode-flora-1.1"
+  - "LicenseRef-scancode-font-alias"
+  - "LicenseRef-scancode-fpl"
+  - "LicenseRef-scancode-fplot"
+  - "LicenseRef-scancode-fraunhofer-iso-14496-10"
+  - "LicenseRef-scancode-free-art-1.3"
+  - "LicenseRef-scancode-freebsd-boot"
+  - "LicenseRef-scancode-freebsd-first"
+  - "LicenseRef-scancode-freemarker"
+  - "LicenseRef-scancode-freetts"
+  - "LicenseRef-scancode-fsf-notice"
+  - "LicenseRef-scancode-fsf-unlimited-no-warranty"
+  - "LicenseRef-scancode-gareth-mccaughan"
+  - "LicenseRef-scancode-gary-s-brown"
+  - "LicenseRef-scancode-gdcl"
+  - "LicenseRef-scancode-geoff-kuenning-1993"
+  - "LicenseRef-scancode-ghostpdl-permissive"
+  - "LicenseRef-scancode-gladman-older-rijndael-code"
+  - "LicenseRef-scancode-glut"
+  - "LicenseRef-scancode-good-boy"
+  - "LicenseRef-scancode-graphics-gems"
+  - "LicenseRef-scancode-greg-roelofs"
+  - "LicenseRef-scancode-gregory-pietsch"
+  - "LicenseRef-scancode-happy-bunny"
+  - "LicenseRef-scancode-hdf4"
+  - "LicenseRef-scancode-hdf5"
+  - "LicenseRef-scancode-hdparm"
+  - "LicenseRef-scancode-hidapi"
+  - "LicenseRef-scancode-historical-ntp"
+  - "LicenseRef-scancode-historical-sell-variant"
+  - "LicenseRef-scancode-homebrewed"
+  - "LicenseRef-scancode-hot-potato"
+  - "LicenseRef-scancode-hp-snmp-pp"
+  - "LicenseRef-scancode-hs-regexp-orig"
+  - "LicenseRef-scancode-html5"
+  - "LicenseRef-scancode-httpget"
+  - "LicenseRef-scancode-ian-kaplan"
+  - "LicenseRef-scancode-ian-piumarta"
+  - "LicenseRef-scancode-ibm-as-is"
+  - "LicenseRef-scancode-ibm-dhcp"
+  - "LicenseRef-scancode-ibm-icu"
+  - "LicenseRef-scancode-ibm-java-portlet-spec-2.0"
+  - "LicenseRef-scancode-ibm-nwsc"
+  - "LicenseRef-scancode-ibm-sample"
+  - "LicenseRef-scancode-ibpp"
+  - "LicenseRef-scancode-icot-free"
+  - "LicenseRef-scancode-idt-notice"
+  - "LicenseRef-scancode-ietf"
+  - "LicenseRef-scancode-ietf-trust"
+  - "LicenseRef-scancode-ilmid"
+  - "LicenseRef-scancode-indiana-extreme"
+  - "LicenseRef-scancode-infineon-free"
+  - "LicenseRef-scancode-info-zip-1997-10"
+  - "LicenseRef-scancode-info-zip-2001-01"
+  - "LicenseRef-scancode-info-zip-2002-02"
+  - "LicenseRef-scancode-info-zip-2003-05"
+  - "LicenseRef-scancode-info-zip-2004-05"
+  - "LicenseRef-scancode-info-zip-2005-02"
+  - "LicenseRef-scancode-info-zip-2007-03"
+  - "LicenseRef-scancode-info-zip-2009-01"
+  - "LicenseRef-scancode-inner-net-2.0"
+  - "LicenseRef-scancode-inno-setup"
+  - "LicenseRef-scancode-intel-bsd"
+  - "LicenseRef-scancode-intel-bsd-2-clause"
+  - "LicenseRef-scancode-intel-osl-1989"
+  - "LicenseRef-scancode-intel-osl-1993"
+  - "LicenseRef-scancode-intel-royalty-free"
+  - "LicenseRef-scancode-iso-14496-10"
+  - "LicenseRef-scancode-iso-8879"
+  - "LicenseRef-scancode-itu"
+  - "LicenseRef-scancode-ja-sig"
+  - "LicenseRef-scancode-jason-mayes"
+  - "LicenseRef-scancode-jasper-1.0"
+  - "LicenseRef-scancode-java-app-stub"
+  - "LicenseRef-scancode-jdbm-1.00"
+  - "LicenseRef-scancode-jdom"
+  - "LicenseRef-scancode-jetty"
+  - "LicenseRef-scancode-jgraph"
+  - "LicenseRef-scancode-jpnic-mdnkit"
+  - "LicenseRef-scancode-jpython-1.1"
+  - "LicenseRef-scancode-jscheme"
+  - "LicenseRef-scancode-jsfromhell"
+  - "LicenseRef-scancode-jython"
+  - "LicenseRef-scancode-kalle-kaukonen"
+  - "LicenseRef-scancode-keith-rule"
+  - "LicenseRef-scancode-kerberos"
+  - "LicenseRef-scancode-kevan-stannard"
+  - "LicenseRef-scancode-kevlin-henney"
+  - "LicenseRef-scancode-khronos"
+  - "LicenseRef-scancode-kumar-robotics"
+  - "LicenseRef-scancode-lcs-telegraphics"
+  - "LicenseRef-scancode-ldap-sdk-free-use"
+  - "LicenseRef-scancode-libcap"
+  - "LicenseRef-scancode-libgeotiff"
+  - "LicenseRef-scancode-libmib"
+  - "LicenseRef-scancode-libmng-2007"
+  - "LicenseRef-scancode-libpbm"
+  - "LicenseRef-scancode-libsrv-1.0.2"
+  - "LicenseRef-scancode-libzip"
+  - "LicenseRef-scancode-lil-1"
+  - "LicenseRef-scancode-lilo"
+  - "LicenseRef-scancode-linum"
+  - "LicenseRef-scancode-linux-device-drivers"
+  - "LicenseRef-scancode-linuxbios"
+  - "LicenseRef-scancode-linuxhowtos"
+  - "LicenseRef-scancode-llnl"
+  - "LicenseRef-scancode-logica-1.0"
+  - "LicenseRef-scancode-lucre"
+  - "LicenseRef-scancode-madwifi-dual"
+  - "LicenseRef-scancode-markus-kuhn-license"
+  - "LicenseRef-scancode-martin-birgmeier"
+  - "LicenseRef-scancode-matt-gallagher-attribution"
+  - "LicenseRef-scancode-matthew-kwan"
+  - "LicenseRef-scancode-mattkruse"
+  - "LicenseRef-scancode-mediainfo-lib"
+  - "LicenseRef-scancode-mentalis"
+  - "LicenseRef-scancode-mgopen-font-license"
+  - "LicenseRef-scancode-michael-barr"
+  - "LicenseRef-scancode-michigan-disclaimer"
+  - "LicenseRef-scancode-minpack"
+  - "LicenseRef-scancode-mit-1995"
+  - "LicenseRef-scancode-mit-addition"
+  - "LicenseRef-scancode-mit-license-1998"
+  - "LicenseRef-scancode-mit-modification-obligations"
+  - "LicenseRef-scancode-mit-nagy"
+  - "LicenseRef-scancode-mit-no-advert-export-control"
+  - "LicenseRef-scancode-mit-no-trademarks"
+  - "LicenseRef-scancode-mit-old-style"
+  - "LicenseRef-scancode-mit-old-style-sparse"
+  - "LicenseRef-scancode-mit-readme"
+  - "LicenseRef-scancode-mit-specification-disclaimer"
+  - "LicenseRef-scancode-mit-synopsys"
+  - "LicenseRef-scancode-mit-taylor-variant"
+  - "LicenseRef-scancode-mit-veillard-variant"
+  - "LicenseRef-scancode-mit-xfig"
+  - "LicenseRef-scancode-mod-dav-1.0"
+  - "LicenseRef-scancode-motorola"
+  - "LicenseRef-scancode-mozilla-gc"
+  - "LicenseRef-scancode-mpeg-iso"
+  - "LicenseRef-scancode-mpeg-ssg"
+  - "LicenseRef-scancode-ms-limited-public"
+  - "LicenseRef-scancode-ms-lpl"
+  - "LicenseRef-scancode-ms-permissive-1.1"
+  - "LicenseRef-scancode-ms-sspl"
+  - "LicenseRef-scancode-ms-ws-routing-spec"
+  - "LicenseRef-scancode-msj-sample-code"
+  - "LicenseRef-scancode-mulanpsl-1.0-en"
+  - "LicenseRef-scancode-mulanpsl-2.0-en"
+  - "LicenseRef-scancode-mulle-kybernetik"
+  - "LicenseRef-scancode-mx4j"
+  - "LicenseRef-scancode-netcat"
+  - "LicenseRef-scancode-netcomponents"
+  - "LicenseRef-scancode-netron"
+  - "LicenseRef-scancode-network-time-protocol"
+  - "LicenseRef-scancode-newlib-historical"
+  - "LicenseRef-scancode-newran"
+  - "LicenseRef-scancode-nice"
+  - "LicenseRef-scancode-nicta-psl"
+  - "LicenseRef-scancode-niels-ferguson"
+  - "LicenseRef-scancode-nilsson-historical"
+  - "LicenseRef-scancode-nist-srd"
+  - "LicenseRef-scancode-node-js"
+  - "LicenseRef-scancode-nonexclusive"
+  - "LicenseRef-scancode-nortel-dasa"
+  - "LicenseRef-scancode-notre-dame"
+  - "LicenseRef-scancode-nrl-permission"
+  - "LicenseRef-scancode-ntlm"
+  - "LicenseRef-scancode-ntpl"
+  - "LicenseRef-scancode-ntpl-origin"
+  - "LicenseRef-scancode-nunit-v2"
+  - "LicenseRef-scancode-nvidia"
+  - "LicenseRef-scancode-nvidia-2002"
+  - "LicenseRef-scancode-nvidia-gov"
+  - "LicenseRef-scancode-nwhm"
+  - "LicenseRef-scancode-nysl-0.9982"
+  - "LicenseRef-scancode-nysl-0.9982-jp"
+  - "LicenseRef-scancode-o-young-jong"
+  - "LicenseRef-scancode-oasis-ws-security-spec"
+  - "LicenseRef-scancode-odl"
+  - "LicenseRef-scancode-odmg"
+  - "LicenseRef-scancode-ogc"
+  - "LicenseRef-scancode-ogc-2006"
+  - "LicenseRef-scancode-ogl-1.0a"
+  - "LicenseRef-scancode-ogl-canada-2.0-fr"
+  - "LicenseRef-scancode-ogl-wpd-3.0"
+  - "LicenseRef-scancode-openmarket-fastcgi"
+  - "LicenseRef-scancode-openorb-1.0"
+  - "LicenseRef-scancode-opensaml-1.0"
+  - "LicenseRef-scancode-openssl"
+  - "LicenseRef-scancode-opml-1.0"
+  - "LicenseRef-scancode-opnl-1.0"
+  - "LicenseRef-scancode-opnl-2.0"
+  - "LicenseRef-scancode-oreilly-notice"
+  - "LicenseRef-scancode-osf-1990"
+  - "LicenseRef-scancode-oswego-concurrent"
+  - "LicenseRef-scancode-owf-cla-1.0-copyright"
+  - "LicenseRef-scancode-owtchart"
+  - "LicenseRef-scancode-ozplb-1.0"
+  - "LicenseRef-scancode-ozplb-1.1"
+  - "LicenseRef-scancode-paolo-messina-2000"
+  - "LicenseRef-scancode-paraview-1.2"
+  - "LicenseRef-scancode-patent-disclaimer"
+  - "LicenseRef-scancode-paul-mackerras"
+  - "LicenseRef-scancode-paul-mackerras-binary"
+  - "LicenseRef-scancode-paul-mackerras-new"
+  - "LicenseRef-scancode-paul-mackerras-simplified"
+  - "LicenseRef-scancode-paulo-soares"
+  - "LicenseRef-scancode-paypal-sdk-2013-2016"
+  - "LicenseRef-scancode-pcre"
+  - "LicenseRef-scancode-pd-mit"
+  - "LicenseRef-scancode-pd-programming"
+  - "LicenseRef-scancode-perl-1.0"
+  - "LicenseRef-scancode-peter-deutsch-document"
+  - "LicenseRef-scancode-philippe-de-muyter"
+  - "LicenseRef-scancode-phorum-2.0"
+  - "LicenseRef-scancode-php-2.0.2"
+  - "LicenseRef-scancode-pine"
+  - "LicenseRef-scancode-pngsuite"
+  - "LicenseRef-scancode-politepix-pl-1.0"
+  - "LicenseRef-scancode-ppp"
+  - "LicenseRef-scancode-protobuf"
+  - "LicenseRef-scancode-psf-3.7.2"
+  - "LicenseRef-scancode-psytec-freesoft"
+  - "LicenseRef-scancode-purdue-bsd"
+  - "LicenseRef-scancode-pybench"
+  - "LicenseRef-scancode-pycrypto"
+  - "LicenseRef-scancode-pygres-2.2"
+  - "LicenseRef-scancode-python-cwi"
+  - "LicenseRef-scancode-qlogic-microcode"
+  - "LicenseRef-scancode-qpopper"
+  - "LicenseRef-scancode-qualcomm-turing"
+  - "LicenseRef-scancode-quickfix-1.0"
+  - "LicenseRef-scancode-quirksmode"
+  - "LicenseRef-scancode-radvd"
+  - "LicenseRef-scancode-ralf-corsepius"
+  - "LicenseRef-scancode-red-hat-attribution"
+  - "LicenseRef-scancode-red-hat-bsd-simplified"
+  - "LicenseRef-scancode-reportbug"
+  - "LicenseRef-scancode-ricebsd"
+  - "LicenseRef-scancode-richard-black"
+  - "LicenseRef-scancode-robert-hubley"
+  - "LicenseRef-scancode-rsa-1990"
+  - "LicenseRef-scancode-rsa-cryptoki"
+  - "LicenseRef-scancode-rsa-demo"
+  - "LicenseRef-scancode-rsa-md4"
+  - "LicenseRef-scancode-rtools-util"
+  - "LicenseRef-scancode-rute"
+  - "LicenseRef-scancode-ryszard-szopa"
+  - "LicenseRef-scancode-saas-mit"
+  - "LicenseRef-scancode-saf"
+  - "LicenseRef-scancode-sash"
+  - "LicenseRef-scancode-sata"
+  - "LicenseRef-scancode-sbia-b"
+  - "LicenseRef-scancode-scancode-acknowledgment"
+  - "LicenseRef-scancode-scanlogd-license"
+  - "LicenseRef-scancode-scansoft-1.2"
+  - "LicenseRef-scancode-scintilla"
+  - "LicenseRef-scancode-scribbles"
+  - "LicenseRef-scancode-script-asylum"
+  - "LicenseRef-scancode-secret-labs-2011"
+  - "LicenseRef-scancode-service-comp-arch"
+  - "LicenseRef-scancode-sgi-cid-1.0"
+  - "LicenseRef-scancode-sgi-glx-1.0"
+  - "LicenseRef-scancode-sglib"
+  - "LicenseRef-scancode-shital-shah"
+  - "LicenseRef-scancode-simpl-1.1"
+  - "LicenseRef-scancode-slf4j-2005"
+  - "LicenseRef-scancode-slf4j-2008"
+  - "LicenseRef-scancode-snprintf"
+  - "LicenseRef-scancode-softfloat"
+  - "LicenseRef-scancode-softfloat-2.0"
+  - "LicenseRef-scancode-softsurfer"
+  - "LicenseRef-scancode-sparky"
+  - "LicenseRef-scancode-speechworks-1.1"
+  - "LicenseRef-scancode-ssleay"
+  - "LicenseRef-scancode-ssleay-windows"
+  - "LicenseRef-scancode-stanford-pvrg"
+  - "LicenseRef-scancode-stlport-2000"
+  - "LicenseRef-scancode-stlport-4.5"
+  - "LicenseRef-scancode-stream-benchmark"
+  - "LicenseRef-scancode-stu-nicholls"
+  - "LicenseRef-scancode-sun-rpc"
+  - "LicenseRef-scancode-sun-source"
+  - "LicenseRef-scancode-sunpro"
+  - "LicenseRef-scancode-sunsoft"
+  - "LicenseRef-scancode-supervisor"
+  - "LicenseRef-scancode-svndiff"
+  - "LicenseRef-scancode-swig"
+  - "LicenseRef-scancode-symphonysoft"
+  - "LicenseRef-scancode-synopsys-mit"
+  - "LicenseRef-scancode-synthesis-toolkit"
+  - "LicenseRef-scancode-takao-abe"
+  - "LicenseRef-scancode-takuya-ooura"
+  - "LicenseRef-scancode-tekhvc"
+  - "LicenseRef-scancode-term-readkey"
+  - "LicenseRef-scancode-tested-software"
+  - "LicenseRef-scancode-tex-live"
+  - "LicenseRef-scancode-things-i-made-public-license"
+  - "LicenseRef-scancode-tiger-crypto"
+  - "LicenseRef-scancode-tigra-calendar-3.2"
+  - "LicenseRef-scancode-tigra-calendar-4.0"
+  - "LicenseRef-scancode-tim-janik-2003"
+  - "LicenseRef-scancode-timestamp-picker"
+  - "LicenseRef-scancode-tso-license"
+  - "LicenseRef-scancode-ttcl"
+  - "LicenseRef-scancode-ttf2pt1"
+  - "LicenseRef-scancode-ttyp0"
+  - "LicenseRef-scancode-tumbolia"
+  - "LicenseRef-scancode-twisted-snmp"
+  - "LicenseRef-scancode-ubc"
+  - "LicenseRef-scancode-unicode"
+  - "LicenseRef-scancode-unicode-data-software"
+  - "LicenseRef-scancode-unicode-icu-58"
+  - "LicenseRef-scancode-unicode-mappings"
+  - "LicenseRef-scancode-unpbook"
+  - "LicenseRef-scancode-us-govt-unlimited-rights"
+  - "LicenseRef-scancode-usrobotics-permissive"
+  - "LicenseRef-scancode-utopia"
+  - "LicenseRef-scancode-vcalendar"
+  - "LicenseRef-scancode-visual-idiot"
+  - "LicenseRef-scancode-visual-numerics"
+  - "LicenseRef-scancode-vixie-cron"
+  - "LicenseRef-scancode-w3c-software-20021231"
+  - "LicenseRef-scancode-westhawk"
+  - "LicenseRef-scancode-whistle"
+  - "LicenseRef-scancode-whitecat"
+  - "LicenseRef-scancode-wide-license"
+  - "LicenseRef-scancode-william-alexander"
+  - "LicenseRef-scancode-wingo"
+  - "LicenseRef-scancode-wol"
+  - "LicenseRef-scancode-wordnet"
+  - "LicenseRef-scancode-wrox"
+  - "LicenseRef-scancode-ws-addressing-spec"
+  - "LicenseRef-scancode-ws-policy-specification"
+  - "LicenseRef-scancode-ws-trust-specification"
+  - "LicenseRef-scancode-wtfnmfpl-1.0"
+  - "LicenseRef-scancode-wxwidgets"
+  - "LicenseRef-scancode-wxwindows-u-3.0"
+  - "LicenseRef-scancode-x11-acer"
+  - "LicenseRef-scancode-x11-adobe"
+  - "LicenseRef-scancode-x11-adobe-dec"
+  - "LicenseRef-scancode-x11-bitstream"
+  - "LicenseRef-scancode-x11-dec1"
+  - "LicenseRef-scancode-x11-dec2"
+  - "LicenseRef-scancode-x11-doc"
+  - "LicenseRef-scancode-x11-dsc"
+  - "LicenseRef-scancode-x11-hanson"
+  - "LicenseRef-scancode-x11-lucent"
+  - "LicenseRef-scancode-x11-lucent-variant"
+  - "LicenseRef-scancode-x11-oar"
+  - "LicenseRef-scancode-x11-opengl"
+  - "LicenseRef-scancode-x11-quarterdeck"
+  - "LicenseRef-scancode-x11-r75"
+  - "LicenseRef-scancode-x11-realmode"
+  - "LicenseRef-scancode-x11-sg"
+  - "LicenseRef-scancode-x11-stanford"
+  - "LicenseRef-scancode-x11-tektronix"
+  - "LicenseRef-scancode-x11-x11r5"
+  - "LicenseRef-scancode-x11-xconsortium-veillard"
+  - "LicenseRef-scancode-x11r5-authors"
+  - "LicenseRef-scancode-xfree86-1.0"
+  - "LicenseRef-scancode-xmldb-1.0"
+  - "LicenseRef-scancode-xxd"
+  - "LicenseRef-scancode-yale-cas"
+  - "LicenseRef-scancode-yensdesign"
+  - "LicenseRef-scancode-zeusbench"
+  - "LicenseRef-scancode-zpl-1.0"
+  - "LicenseRef-scancode-zsh"
+  - "LicenseRef-scancode-zuora-software"
+  - "LicenseRef-scancode-zveno-research"
+  - "Linux-OpenIB"
+  - "MIT"
+  - "MIT-0"
+  - "MIT-CMU"
+  - "MIT-Modern-Variant"
+  - "MIT-advertising"
+  - "MIT-enna"
+  - "MIT-feh"
+  - "MIT-open-group"
+  - "MITNFA"
+  - "MS-PL"
+  - "MTLL"
+  - "MirOS"
+  - "MulanPSL-1.0"
+  - "MulanPSL-2.0"
+  - "Multics"
+  - "Mup"
+  - "NAIST-2003"
+  - "NCSA"
+  - "NIST-PD-fallback"
+  - "NLOD-1.0"
+  - "NLOD-2.0"
+  - "NRL"
+  - "NTP"
+  - "NTP-0"
+  - "Naumen"
+  - "Net-SNMP"
+  - "NetCDF"
+  - "Newsletr"
+  - "O-UDA-1.0"
+  - "ODC-By-1.0"
+  - "OFL-1.0"
+  - "OFL-1.0-RFN"
+  - "OFL-1.0-no-RFN"
+  - "OFL-1.1"
+  - "OFL-1.1-RFN"
+  - "OFL-1.1-no-RFN"
+  - "OGC-1.0"
+  - "OGDL-Taiwan-1.0"
+  - "OGL-Canada-2.0"
+  - "OGL-UK-1.0"
+  - "OGL-UK-2.0"
+  - "OGL-UK-3.0"
+  - "OLDAP-2.0"
+  - "OLDAP-2.0.1"
+  - "OLDAP-2.1"
+  - "OLDAP-2.2"
+  - "OLDAP-2.2.1"
+  - "OLDAP-2.2.2"
+  - "OLDAP-2.3"
+  - "OLDAP-2.4"
+  - "OLDAP-2.5"
+  - "OLDAP-2.6"
+  - "OLDAP-2.7"
+  - "OLDAP-2.8"
+  - "OML"
+  - "OPUBL-1.0"
+  - "OpenSSL"
+  - "PHP-3.0"
+  - "PHP-3.01"
+  - "PSF-2.0"
+  - "Plexus"
+  - "PostgreSQL"
+  - "Python-2.0"
+  - "RSA-MD"
+  - "Rdisc"
+  - "SCEA"
+  - "SGI-B-1.1"
+  - "SGI-B-2.0"
+  - "SHL-0.5"
+  - "SHL-0.51"
+  - "SMLNJ"
+  - "SSH-OpenSSH"
+  - "SSH-short"
+  - "SWL"
+  - "Saxpath"
+  - "SchemeReport"
+  - "Sendmail"
+  - "Spencer-86"
+  - "Spencer-94"
+  - "Spencer-99"
+  - "TCL"
+  - "TCP-wrappers"
+  - "TU-Berlin-1.0"
+  - "TU-Berlin-2.0"
+  - "UPL-1.0"
+  - "Unicode-DFS-2015"
+  - "Unicode-DFS-2016"
+  - "VSL-1.0"
+  - "W3C"
+  - "W3C-19980720"
+  - "W3C-20150513"
+  - "Wsuipa"
+  - "X11"
+  - "X11-distribute-modifications-variant"
+  - "XFree86-1.1"
+  - "XSkat"
+  - "Xerox"
+  - "Xnet"
+  - "ZPL-1.1"
+  - "ZPL-2.0"
+  - "ZPL-2.1"
+  - "Zed"
+  - "Zend-2.0"
+  - "Zlib"
+  - "bzip2-1.0.6"
+  - "curl"
+  - "dvipdfm"
+  - "eGenix"
+  - "etalab-2.0"
+  - "iMatix"
+  - "libpng-2.0"
+  - "libtiff"
+  - "mpich2"
+  - "mplus"
+  - "psfrag"
+  - "psutils"
+  - "xinetd"
+  - "xpp"
+  - "zlib-acknowledgement"
+  copyleft:
+  - "AGPL-1.0-only"
+  - "AGPL-1.0-or-later"
+  - "AGPL-3.0-only"
+  - "AGPL-3.0-or-later"
+  - "APL-1.0"
+  - "Aladdin"
+  - "Arphic-1999"
+  - "BSD-Protection"
+  - "CAL-1.0"
+  - "CECILL-1.0"
+  - "CECILL-C"
+  - "CERN-OHL-S-2.0"
+  - "CPAL-1.0"
+  - "D-FSL-1.0"
+  - "EUPL-1.0"
+  - "ErlPL-1.1"
+  - "GPL-1.0-only"
+  - "GPL-1.0-or-later"
+  - "GPL-2.0-only"
+  - "GPL-2.0-or-later"
+  - "GPL-3.0-only"
+  - "GPL-3.0-or-later"
+  - "Glide"
+  - "Interbase-1.0"
+  - "LAL-1.2"
+  - "LAL-1.3"
+  - "LPPL-1.0"
+  - "LPPL-1.1"
+  - "LPPL-1.2"
+  - "LPPL-1.3a"
+  - "LPPL-1.3c"
+  - "LiLiQ-Rplus-1.1"
+  - "LicenseRef-scancode-ac3filter"
+  - "LicenseRef-scancode-afpl-9.0"
+  - "LicenseRef-scancode-agpl-2.0"
+  - "LicenseRef-scancode-anepokis-1.0"
+  - "LicenseRef-scancode-aslr"
+  - "LicenseRef-scancode-broadcom-dual"
+  - "LicenseRef-scancode-cc-gpl-2.0-pt"
+  - "LicenseRef-scancode-ccrc-1.0"
+  - "LicenseRef-scancode-cecill-1.0-en"
+  - "LicenseRef-scancode-crypto-keys-redistribution"
+  - "LicenseRef-scancode-cups"
+  - "LicenseRef-scancode-d-fsl-1.0-en"
+  - "LicenseRef-scancode-dbcl-1.0"
+  - "LicenseRef-scancode-defensive-patent-1.1"
+  - "LicenseRef-scancode-devblocks-1.0"
+  - "LicenseRef-scancode-dual-commercial-gpl"
+  - "LicenseRef-scancode-ecosrh-1.0"
+  - "LicenseRef-scancode-elib-gpl"
+  - "LicenseRef-scancode-epo-osl-2005.1"
+  - "LicenseRef-scancode-flowplayer-gpl-3.0"
+  - "LicenseRef-scancode-ghostscript-1988"
+  - "LicenseRef-scancode-gnu-emacs-gpl-1988"
+  - "LicenseRef-scancode-gpl-2.0-adaptec"
+  - "LicenseRef-scancode-gpl-2.0-djvu"
+  - "LicenseRef-scancode-gpl-2.0-koterov"
+  - "LicenseRef-scancode-gust-font-1.0"
+  - "LicenseRef-scancode-gust-font-2006-09-30"
+  - "LicenseRef-scancode-hacos-1.2"
+  - "LicenseRef-scancode-initial-developer-public"
+  - "LicenseRef-scancode-itu-t-gpl"
+  - "LicenseRef-scancode-jahia-1.3.1"
+  - "LicenseRef-scancode-jelurida-public-1.1"
+  - "LicenseRef-scancode-kde-accepted-gpl"
+  - "LicenseRef-scancode-kde-accepted-lgpl"
+  - "LicenseRef-scancode-ldpc-1994"
+  - "LicenseRef-scancode-ldpc-1997"
+  - "LicenseRef-scancode-ldpc-1999"
+  - "LicenseRef-scancode-ldpgpl-1"
+  - "LicenseRef-scancode-ldpgpl-1a"
+  - "LicenseRef-scancode-ldpl-2.0"
+  - "LicenseRef-scancode-ldpm-1998"
+  - "LicenseRef-scancode-maxmind-geolite2-eula-2019"
+  - "LicenseRef-scancode-merit-network-derivative"
+  - "LicenseRef-scancode-metrolink-1.0"
+  - "LicenseRef-scancode-msntp"
+  - "LicenseRef-scancode-odc-1.0"
+  - "LicenseRef-scancode-okl"
+  - "LicenseRef-scancode-open-diameter"
+  - "LicenseRef-scancode-rh-eula"
+  - "LicenseRef-scancode-smail-gpl"
+  - "LicenseRef-scancode-tanuki-community-sla-1.0"
+  - "LicenseRef-scancode-tanuki-community-sla-1.1"
+  - "LicenseRef-scancode-tanuki-community-sla-1.2"
+  - "LicenseRef-scancode-tanuki-community-sla-1.3"
+  - "LicenseRef-scancode-tgppl-1.0"
+  - "LicenseRef-scancode-vhfpl-1.1"
+  - "LicenseRef-scancode-vita-nuova-liberal"
+  - "LicenseRef-scancode-x11-ibm"
+  - "Linux-man-pages-copyleft"
+  - "MakeIndex"
+  - "Motosoto"
+  - "NPOSL-3.0"
+  - "ODbL-1.0"
+  - "OSL-1.0"
+  - "OSL-1.1"
+  - "OSL-2.0"
+  - "OSL-2.1"
+  - "OSL-3.0"
+  - "Parity-6.0.0"
+  - "Parity-7.0.0"
+  - "RHeCos-1.1"
+  - "SNIA"
+  - "SimPL-2.0"
+  - "Sleepycat"
+  - "SugarCRM-1.1.3"
+  - "TMate"
+  - "TOSL"
+  - "VOSTROM"
+  - "Vim"
+  - "YPL-1.1"
+  - "copyleft-next-0.3.0"
+  - "copyleft-next-0.3.1"
+  public-domain:
+  - "ANTLR-PD-fallback"
+  - "CC-PDDC"
+  - "CC0-1.0"
+  - "FSFUL"
+  - "LicenseRef-scancode-aes-128-3.0"
+  - "LicenseRef-scancode-aop-pd"
+  - "LicenseRef-scancode-cc-pdm-1.0"
+  - "LicenseRef-scancode-copyheart"
+  - "LicenseRef-scancode-doug-lea"
+  - "LicenseRef-scancode-icann-public"
+  - "LicenseRef-scancode-jquery-pd"
+  - "LicenseRef-scancode-json-js-pd"
+  - "LicenseRef-scancode-json-pd"
+  - "LicenseRef-scancode-libselinux-pd"
+  - "LicenseRef-scancode-lzma-sdk-pd"
+  - "LicenseRef-scancode-ncbi"
+  - "LicenseRef-scancode-phil-bunce"
+  - "LicenseRef-scancode-tfl"
+  - "LicenseRef-scancode-vic-metcalfe-pd"
+  - "LicenseRef-scancode-wtfpl-1.0"
+  - "LicenseRef-scancode-wthpl-1.0"
+  - "NIST-PD"
+  - "NLPL"
+  - "PDDL-1.0"
+  - "SAX-PD"
+  - "Unlicense"
+  - "WTFPL"
+  - "blessing"
+  - "diffmark"
+  - "libselinux-1.0"
+  copyleft-limited:
+  - "APSL-1.0"
+  - "APSL-1.1"
+  - "APSL-1.2"
+  - "APSL-2.0"
+  - "Artistic-1.0"
+  - "Artistic-1.0-Perl"
+  - "Artistic-1.0-cl8"
+  - "Artistic-2.0"
+  - "BitTorrent-1.0"
+  - "BitTorrent-1.1"
+  - "CAL-1.0-Combined-Work-Exception"
+  - "CATOSL-1.1"
+  - "CC-BY-SA-1.0"
+  - "CC-BY-SA-2.0"
+  - "CC-BY-SA-2.0-UK"
+  - "CC-BY-SA-2.1-JP"
+  - "CC-BY-SA-2.5"
+  - "CC-BY-SA-3.0"
+  - "CC-BY-SA-3.0-AT"
+  - "CC-BY-SA-3.0-DE"
+  - "CC-BY-SA-4.0"
+  - "CDDL-1.0"
+  - "CDDL-1.1"
+  - "CDL-1.0"
+  - "CDLA-Sharing-1.0"
+  - "CECILL-1.1"
+  - "CECILL-2.0"
+  - "CECILL-2.1"
+  - "CERN-OHL-W-2.0"
+  - "CPL-1.0"
+  - "CUA-OPL-1.0"
+  - "ClArtistic"
+  - "EPL-1.0"
+  - "EPL-2.0"
+  - "EUPL-1.1"
+  - "EUPL-1.2"
+  - "Eurosym"
+  - "FDK-AAC"
+  - "Frameworx-1.0"
+  - "FreeImage"
+  - "GFDL-1.1-invariants-only"
+  - "GFDL-1.1-invariants-or-later"
+  - "GFDL-1.1-no-invariants-only"
+  - "GFDL-1.1-no-invariants-or-later"
+  - "GFDL-1.1-only"
+  - "GFDL-1.1-or-later"
+  - "GFDL-1.2-invariants-only"
+  - "GFDL-1.2-invariants-or-later"
+  - "GFDL-1.2-no-invariants-only"
+  - "GFDL-1.2-no-invariants-or-later"
+  - "GFDL-1.2-only"
+  - "GFDL-1.2-or-later"
+  - "GFDL-1.3-invariants-only"
+  - "GFDL-1.3-invariants-or-later"
+  - "GFDL-1.3-no-invariants-only"
+  - "GFDL-1.3-no-invariants-or-later"
+  - "GFDL-1.3-only"
+  - "GFDL-1.3-or-later"
+  - "GL2PS"
+  - "IPA"
+  - "IPL-1.0"
+  - "Imlib2"
+  - "KiCad-libraries-exception"
+  - "LGPL-2.0-only"
+  - "LGPL-2.0-or-later"
+  - "LGPL-2.1-only"
+  - "LGPL-2.1-or-later"
+  - "LGPL-3.0-only"
+  - "LGPL-3.0-or-later"
+  - "LGPLLR"
+  - "LPL-1.0"
+  - "LPL-1.02"
+  - "LiLiQ-P-1.1"
+  - "LiLiQ-R-1.1"
+  - "LicenseRef-scancode-altermime"
+  - "LicenseRef-scancode-apl-1.1"
+  - "LicenseRef-scancode-aptana-1.0"
+  - "LicenseRef-scancode-artistic-1988-1.0"
+  - "LicenseRef-scancode-bittorrent-1.2"
+  - "LicenseRef-scancode-blitz-artistic"
+  - "LicenseRef-scancode-c-fsl-1.1"
+  - "LicenseRef-scancode-cc-lgpl-2.1-pt"
+  - "LicenseRef-scancode-cecill-2.0-fr"
+  - "LicenseRef-scancode-cecill-2.1-fr"
+  - "LicenseRef-scancode-cecill-c-en"
+  - "LicenseRef-scancode-cognitive-web-osl-1.1"
+  - "LicenseRef-scancode-cpl-0.5"
+  - "LicenseRef-scancode-divx-open-1.0"
+  - "LicenseRef-scancode-divx-open-2.1"
+  - "LicenseRef-scancode-dpl-1.1"
+  - "LicenseRef-scancode-eclipse-sua-2001"
+  - "LicenseRef-scancode-eclipse-sua-2002"
+  - "LicenseRef-scancode-eclipse-sua-2003"
+  - "LicenseRef-scancode-eclipse-sua-2004"
+  - "LicenseRef-scancode-eclipse-sua-2005"
+  - "LicenseRef-scancode-eclipse-sua-2010"
+  - "LicenseRef-scancode-eclipse-sua-2011"
+  - "LicenseRef-scancode-eclipse-sua-2014"
+  - "LicenseRef-scancode-eclipse-sua-2014-11"
+  - "LicenseRef-scancode-eclipse-sua-2017"
+  - "LicenseRef-scancode-enhydra-1.1"
+  - "LicenseRef-scancode-free-fork"
+  - "LicenseRef-scancode-frontier-1.0"
+  - "LicenseRef-scancode-gsoap-1.3a"
+  - "LicenseRef-scancode-h2-1.0"
+  - "LicenseRef-scancode-josl-1.0"
+  - "LicenseRef-scancode-llgpl"
+  - "LicenseRef-scancode-losla"
+  - "LicenseRef-scancode-lzma-sdk-2006"
+  - "LicenseRef-scancode-lzma-sdk-2008"
+  - "LicenseRef-scancode-lzma-sdk-original"
+  - "LicenseRef-scancode-monetdb-1.1"
+  - "LicenseRef-scancode-ms-cl"
+  - "LicenseRef-scancode-mule-source-1.1.3"
+  - "LicenseRef-scancode-mule-source-1.1.4"
+  - "LicenseRef-scancode-oclc-1.0"
+  - "LicenseRef-scancode-ocsl-1.0"
+  - "LicenseRef-scancode-oculus-sdk"
+  - "LicenseRef-scancode-ohdl-1.0"
+  - "LicenseRef-scancode-open-group"
+  - "LicenseRef-scancode-openi-pl-1.0"
+  - "LicenseRef-scancode-openmap"
+  - "LicenseRef-scancode-openpbs-2.3"
+  - "LicenseRef-scancode-opl-1.0"
+  - "LicenseRef-scancode-osetpl-2.1"
+  - "LicenseRef-scancode-pdl-1.0"
+  - "LicenseRef-scancode-pftijah-1.1"
+  - "LicenseRef-scancode-qwt-1.0"
+  - "LicenseRef-scancode-rh-eula-lgpl"
+  - "LicenseRef-scancode-scsl-3.0"
+  - "LicenseRef-scancode-stanford-mrouted"
+  - "LicenseRef-scancode-statewizard"
+  - "LicenseRef-scancode-stax"
+  - "LicenseRef-scancode-sun-ssscfr-1.1"
+  - "LicenseRef-scancode-thor-pl"
+  - "LicenseRef-scancode-tpl-1.0"
+  - "LicenseRef-scancode-truecrypt-3.1"
+  - "LicenseRef-scancode-volatility-vsl-v1.0"
+  - "LicenseRef-scancode-vpl-1.1"
+  - "LicenseRef-scancode-vpl-1.2"
+  - "LicenseRef-scancode-wxwindows-r-3.0"
+  - "MPL-1.0"
+  - "MPL-1.1"
+  - "MPL-2.0"
+  - "MPL-2.0-no-copyleft-exception"
+  - "MS-RL"
+  - "NASA-1.3"
+  - "NBPL-1.0"
+  - "NGPL"
+  - "NOSL"
+  - "NPL-1.0"
+  - "NPL-1.1"
+  - "Nokia"
+  - "Noweb"
+  - "OCCT-PL"
+  - "OCLC-2.0"
+  - "OGTSL"
+  - "OLDAP-1.1"
+  - "OLDAP-1.2"
+  - "OLDAP-1.3"
+  - "OLDAP-1.4"
+  - "OPL-1.0"
+  - "OSET-PL-2.1"
+  - "QPL-1.0"
+  - "Qhull"
+  - "RPL-1.1"
+  - "RPL-1.5"
+  - "RPSL-1.0"
+  - "RSCPL"
+  - "Ruby"
+  - "SMPPL"
+  - "SPL-1.0"
+  - "Sendmail-8.23"
+  - "TAPR-OHL-1.0"
+  - "TORQUE-1.1"
+  - "UCL-1.0"
+  - "YPL-1.0"
+  - "Zimbra-1.3"
+  - "Zimbra-1.4"
+  - "gSOAP-1.3b"
+  - "gnuplot"
+  - "wxWindows"
+  free-restricted:
+  - "BSD-3-Clause-No-Military-License"
+  - "BSD-3-Clause-No-Nuclear-License"
+  - "BSD-3-Clause-No-Nuclear-License-2014"
+  - "BSD-3-Clause-No-Nuclear-Warranty"
+  - "C-UDA-1.0"
+  - "CC-BY-NC-3.0-DE"
+  - "CC-BY-NC-ND-3.0-DE"
+  - "CC-BY-ND-3.0-DE"
+  - "CPOL-1.02"
+  - "Hippocratic-2.1"
+  - "LicenseRef-scancode-996-icu-1.0"
+  - "LicenseRef-scancode-Hippocratic-3.0"
+  - "LicenseRef-scancode-allen-institute-software-2018"
+  - "LicenseRef-scancode-anti-capitalist-1.4"
+  - "LicenseRef-scancode-apple-mpeg-4"
+  - "LicenseRef-scancode-aslp"
+  - "LicenseRef-scancode-brad-martinez-vb-32"
+  - "LicenseRef-scancode-bsd-no-mod"
+  - "LicenseRef-scancode-cavium-targeted-hardware"
+  - "LicenseRef-scancode-cc-by-nc-nd-2.0-at"
+  - "LicenseRef-scancode-cclrc"
+  - "LicenseRef-scancode-colt"
+  - "LicenseRef-scancode-cosli"
+  - "LicenseRef-scancode-cpol-1.0"
+  - "LicenseRef-scancode-csla"
+  - "LicenseRef-scancode-dennis-ferguson"
+  - "LicenseRef-scancode-dl-de-by-nc-1-0-de"
+  - "LicenseRef-scancode-dl-de-by-nc-1-0-en"
+  - "LicenseRef-scancode-dynarch-linkware"
+  - "LicenseRef-scancode-ecma-documentation"
+  - "LicenseRef-scancode-gcel-2022"
+  - "LicenseRef-scancode-hippocratic-1.0"
+  - "LicenseRef-scancode-hippocratic-1.1"
+  - "LicenseRef-scancode-hippocratic-1.2"
+  - "LicenseRef-scancode-hippocratic-2.0"
+  - "LicenseRef-scancode-hp-netperf"
+  - "LicenseRef-scancode-ic-1.0"
+  - "LicenseRef-scancode-ic-shared-1.0"
+  - "LicenseRef-scancode-imagen"
+  - "LicenseRef-scancode-installsite"
+  - "LicenseRef-scancode-issl-2018"
+  - "LicenseRef-scancode-itu-t"
+  - "LicenseRef-scancode-jam-stapl"
+  - "LicenseRef-scancode-jamon"
+  - "LicenseRef-scancode-jj2000"
+  - "LicenseRef-scancode-jprs-oscl-1.1"
+  - "LicenseRef-scancode-karl-peterson"
+  - "LicenseRef-scancode-lha"
+  - "LicenseRef-scancode-mame"
+  - "LicenseRef-scancode-manfred-klein-fonts-tos"
+  - "LicenseRef-scancode-matthew-welch-font-license"
+  - "LicenseRef-scancode-maxmind-odl"
+  - "LicenseRef-scancode-mike95"
+  - "LicenseRef-scancode-mvt-1.1"
+  - "LicenseRef-scancode-naughter"
+  - "LicenseRef-scancode-oracle-code-samples-bsd"
+  - "LicenseRef-scancode-paul-hsieh-derivative"
+  - "LicenseRef-scancode-paul-hsieh-exposition"
+  - "LicenseRef-scancode-pbl-1.0"
+  - "LicenseRef-scancode-pixabay-content"
+  - "LicenseRef-scancode-planet-source-code"
+  - "LicenseRef-scancode-qualcomm-iso"
+  - "LicenseRef-scancode-rackspace"
+  - "LicenseRef-scancode-riverbank-sip"
+  - "LicenseRef-scancode-rsa-md2"
+  - "LicenseRef-scancode-st-bsd-restricted"
+  - "LicenseRef-scancode-stmicroelectronics-centrallabs"
+  - "LicenseRef-scancode-sun-bsd-extra"
+  - "LicenseRef-scancode-sun-no-high-risk-activities"
+  - "LicenseRef-scancode-sun-sissl-1.0"
+  - "LicenseRef-scancode-sustainable-use-1.0"
+  - "LicenseRef-scancode-synopsys-attribution"
+  - "LicenseRef-scancode-thomas-bandt"
+  - "LicenseRef-scancode-trca-odl-1.0"
+  - "LicenseRef-scancode-txl-10.5"
+  - "LicenseRef-scancode-ubuntu-font-1.0"
+  - "LicenseRef-scancode-unbuntu-font-1.0"
+  - "LicenseRef-scancode-unsplash"
+  - "LicenseRef-scancode-vbaccelerator"
+  - "LicenseRef-scancode-w3c-docs-19990405"
+  - "LicenseRef-scancode-w3c-docs-20021231"
+  - "LicenseRef-scancode-w3c-documentation"
+  - "LicenseRef-scancode-w3c-test-suite"
+  - "LicenseRef-scancode-waterfall-feed-parser"
+  - "LicenseRef-scancode-xilinx-2016"
+  - "NCGL-UK-2.0"
+  - "SGI-B-1.0"
+  source-available:
+  - "BUSL-1.1"
+  - "CC-BY-NC-1.0"
+  - "CC-BY-NC-2.0"
+  - "CC-BY-NC-2.5"
+  - "CC-BY-NC-3.0"
+  - "CC-BY-NC-4.0"
+  - "CC-BY-NC-ND-1.0"
+  - "CC-BY-NC-ND-2.0"
+  - "CC-BY-NC-ND-2.5"
+  - "CC-BY-NC-ND-3.0"
+  - "CC-BY-NC-ND-3.0-IGO"
+  - "CC-BY-NC-ND-4.0"
+  - "CC-BY-NC-SA-1.0"
+  - "CC-BY-NC-SA-2.0"
+  - "CC-BY-NC-SA-2.0-FR"
+  - "CC-BY-NC-SA-2.0-UK"
+  - "CC-BY-NC-SA-2.5"
+  - "CC-BY-NC-SA-3.0"
+  - "CC-BY-NC-SA-3.0-DE"
+  - "CC-BY-NC-SA-3.0-IGO"
+  - "CC-BY-NC-SA-4.0"
+  - "CC-BY-ND-1.0"
+  - "CC-BY-ND-2.0"
+  - "CC-BY-ND-2.5"
+  - "CC-BY-ND-3.0"
+  - "CC-BY-ND-4.0"
+  - "Elastic-2.0"
+  - "LicenseRef-scancode-atmosphere-0.4"
+  - "LicenseRef-scancode-bapl-1.0"
+  - "LicenseRef-scancode-bitwarden-1.0"
+  - "LicenseRef-scancode-bsl-1.0"
+  - "LicenseRef-scancode-cc-by-nc-nd-2.0-au"
+  - "LicenseRef-scancode-cc-by-nc-sa-3.0-us"
+  - "LicenseRef-scancode-cockroach"
+  - "LicenseRef-scancode-confluent-community-1.0"
+  - "LicenseRef-scancode-dgraph-cla"
+  - "LicenseRef-scancode-elastic-license-2018"
+  - "LicenseRef-scancode-fair-source-0.9"
+  - "LicenseRef-scancode-hazelcast-community-1.0"
+  - "LicenseRef-scancode-hugo"
+  - "LicenseRef-scancode-polyform-defensive-1.0.0"
+  - "LicenseRef-scancode-polyform-free-trial-1.0.0"
+  - "LicenseRef-scancode-polyform-internal-use-1.0.0"
+  - "LicenseRef-scancode-polyform-perimeter-1.0.0"
+  - "LicenseRef-scancode-polyform-shield-1.0.0"
+  - "LicenseRef-scancode-prosperity-2.0"
+  - "LicenseRef-scancode-prosperity-3.0"
+  - "LicenseRef-scancode-redis-source-available-1.0"
+  - "LicenseRef-scancode-tsl-2018"
+  - "LicenseRef-scancode-tsl-2020"
+  - "LicenseRef-scancode-unrar"
+  - "LicenseRef-scancode-wrox-download"
+  - "PolyForm-Noncommercial-1.0.0"
+  - "PolyForm-Small-Business-1.0.0"
+  - "SSPL-1.0"
+  proprietary-free:
+  - "LicenseRef-.amazon.com.-AmznSL-1.0"
+  - "LicenseRef-scancode-abrms"
+  - "LicenseRef-scancode-acroname-bdk"
+  - "LicenseRef-scancode-activestate-community"
+  - "LicenseRef-scancode-activestate-community-2012"
+  - "LicenseRef-scancode-activestate-komodo-edit"
+  - "LicenseRef-scancode-actuate-birt-ihub-ftype-sla"
+  - "LicenseRef-scancode-adaptec-downloadable"
+  - "LicenseRef-scancode-adaptec-eula"
+  - "LicenseRef-scancode-addthis-mobile-sdk-1.0"
+  - "LicenseRef-scancode-adobe-acrobat-reader-eula"
+  - "LicenseRef-scancode-adobe-air-sdk"
+  - "LicenseRef-scancode-adobe-air-sdk-2014"
+  - "LicenseRef-scancode-adobe-color-profile-bundling"
+  - "LicenseRef-scancode-adobe-color-profile-license"
+  - "LicenseRef-scancode-adobe-dng-sdk"
+  - "LicenseRef-scancode-adobe-flash-player-eula-21.0"
+  - "LicenseRef-scancode-adobe-flex-4-sdk"
+  - "LicenseRef-scancode-adobe-flex-sdk"
+  - "LicenseRef-scancode-adobe-indesign-sdk"
+  - "LicenseRef-scancode-adobe-postscript"
+  - "LicenseRef-scancode-agere-sla"
+  - "LicenseRef-scancode-ago-private-1.0"
+  - "LicenseRef-scancode-alasir"
+  - "LicenseRef-scancode-amazon-redshift-jdbc"
+  - "LicenseRef-scancode-amd-linux-firmware"
+  - "LicenseRef-scancode-amd-linux-firmware-export"
+  - "LicenseRef-scancode-amlogic-linux-firmware"
+  - "LicenseRef-scancode-android-sdk-2009"
+  - "LicenseRef-scancode-android-sdk-2012"
+  - "LicenseRef-scancode-android-sdk-2021"
+  - "LicenseRef-scancode-android-sdk-license"
+  - "LicenseRef-scancode-android-sdk-preview-2015"
+  - "LicenseRef-scancode-appfire-eula"
+  - "LicenseRef-scancode-apple-mfi-license"
+  - "LicenseRef-scancode-appsflyer-framework"
+  - "LicenseRef-scancode-arachni-psl-1.0"
+  - "LicenseRef-scancode-arm-cortex-mx"
+  - "LicenseRef-scancode-ati-eula"
+  - "LicenseRef-scancode-atlassian-marketplace-tou"
+  - "LicenseRef-scancode-atmel-firmware"
+  - "LicenseRef-scancode-atmel-linux-firmware"
+  - "LicenseRef-scancode-atmel-microcontroller"
+  - "LicenseRef-scancode-autoit-eula"
+  - "LicenseRef-scancode-binary-linux-firmware"
+  - "LicenseRef-scancode-binary-linux-firmware-patent"
+  - "LicenseRef-scancode-bittorrent-eula"
+  - "LicenseRef-scancode-bloomberg-blpapi"
+  - "LicenseRef-scancode-bpel4ws-spec"
+  - "LicenseRef-scancode-broadcom-linux-firmware"
+  - "LicenseRef-scancode-broadcom-proprietary"
+  - "LicenseRef-scancode-broadcom-raspberry-pi"
+  - "LicenseRef-scancode-broadcom-wiced"
+  - "LicenseRef-scancode-broadleaf-fair-use"
+  - "LicenseRef-scancode-bugsense-sdk"
+  - "LicenseRef-scancode-cadence-linux-firmware"
+  - "LicenseRef-scancode-cavium-linux-firmware"
+  - "LicenseRef-scancode-cc-devnations-2.0"
+  - "LicenseRef-scancode-cc-nc-sampling-plus-1.0"
+  - "LicenseRef-scancode-cc-sampling-1.0"
+  - "LicenseRef-scancode-cc-sampling-plus-1.0"
+  - "LicenseRef-scancode-chartdirector-6.0"
+  - "LicenseRef-scancode-chelsio-linux-firmware"
+  - "LicenseRef-scancode-christopher-velazquez"
+  - "LicenseRef-scancode-cloudera-express"
+  - "LicenseRef-scancode-cmigemo"
+  - "LicenseRef-scancode-codexia"
+  - "LicenseRef-scancode-concursive-pl-1.0"
+  - "LicenseRef-scancode-cooperative-non-violent-4.0"
+  - "LicenseRef-scancode-corporate-accountability-1.1"
+  - "LicenseRef-scancode-couchbase-community"
+  - "LicenseRef-scancode-couchbase-enterprise"
+  - "LicenseRef-scancode-crapl-0.1"
+  - "LicenseRef-scancode-ctl-linux-firmware"
+  - "LicenseRef-scancode-cvwl"
+  - "LicenseRef-scancode-cypress-linux-firmware"
+  - "LicenseRef-scancode-day-spec"
+  - "LicenseRef-scancode-dbad"
+  - "LicenseRef-scancode-do-no-harm-0.1"
+  - "LicenseRef-scancode-duende-sla-2022"
+  - "LicenseRef-scancode-ecma-patent-coc-0"
+  - "LicenseRef-scancode-ecma-patent-coc-1"
+  - "LicenseRef-scancode-ecma-patent-coc-2"
+  - "LicenseRef-scancode-efsl-1.0"
+  - "LicenseRef-scancode-esri-devkit"
+  - "LicenseRef-scancode-examdiff"
+  - "LicenseRef-scancode-facebook-nuclide"
+  - "LicenseRef-scancode-facebook-software-license"
+  - "LicenseRef-scancode-fancyzoom"
+  - "LicenseRef-scancode-first-works-appreciative-1.2"
+  - "LicenseRef-scancode-flex2sdk"
+  - "LicenseRef-scancode-foobar2000"
+  - "LicenseRef-scancode-froala-owdl-1.0"
+  - "LicenseRef-scancode-ftdi"
+  - "LicenseRef-scancode-ftpbean"
+  - "LicenseRef-scancode-gco-v3.0"
+  - "LicenseRef-scancode-goahead"
+  - "LicenseRef-scancode-google-analytics-tos"
+  - "LicenseRef-scancode-google-analytics-tos-2015"
+  - "LicenseRef-scancode-google-analytics-tos-2016"
+  - "LicenseRef-scancode-google-analytics-tos-2019"
+  - "LicenseRef-scancode-google-apis-tos-2021"
+  - "LicenseRef-scancode-google-maps-tos-2018-02-07"
+  - "LicenseRef-scancode-google-maps-tos-2018-05-01"
+  - "LicenseRef-scancode-google-maps-tos-2018-06-07"
+  - "LicenseRef-scancode-google-maps-tos-2018-07-09"
+  - "LicenseRef-scancode-google-maps-tos-2018-07-19"
+  - "LicenseRef-scancode-google-maps-tos-2018-10-01"
+  - "LicenseRef-scancode-google-maps-tos-2018-10-31"
+  - "LicenseRef-scancode-google-maps-tos-2019-05-02"
+  - "LicenseRef-scancode-google-maps-tos-2019-11-21"
+  - "LicenseRef-scancode-google-maps-tos-2020-04-02"
+  - "LicenseRef-scancode-google-maps-tos-2020-04-27"
+  - "LicenseRef-scancode-google-maps-tos-2020-05-06"
+  - "LicenseRef-scancode-google-ml-kit-tos-2022"
+  - "LicenseRef-scancode-google-playcore-sdk-tos-2020"
+  - "LicenseRef-scancode-google-tos-2013"
+  - "LicenseRef-scancode-google-tos-2014"
+  - "LicenseRef-scancode-google-tos-2017"
+  - "LicenseRef-scancode-google-tos-2019"
+  - "LicenseRef-scancode-google-tos-2020"
+  - "LicenseRef-scancode-gutenberg-2020"
+  - "LicenseRef-scancode-hauppauge-firmware-eula"
+  - "LicenseRef-scancode-hauppauge-firmware-oem"
+  - "LicenseRef-scancode-helix"
+  - "LicenseRef-scancode-hessla"
+  - "LicenseRef-scancode-hp"
+  - "LicenseRef-scancode-hp-enterprise-eula"
+  - "LicenseRef-scancode-hp-software-eula"
+  - "LicenseRef-scancode-hp-ux-java"
+  - "LicenseRef-scancode-hp-ux-jre"
+  - "LicenseRef-scancode-hxd"
+  - "LicenseRef-scancode-ibm-developerworks-community"
+  - "LicenseRef-scancode-intel"
+  - "LicenseRef-scancode-intel-bcl"
+  - "LicenseRef-scancode-intel-code-samples"
+  - "LicenseRef-scancode-intel-firmware"
+  - "LicenseRef-scancode-intel-master-eula-sw-dev-2016"
+  - "LicenseRef-scancode-intel-mcu-2018"
+  - "LicenseRef-scancode-intel-microcode"
+  - "LicenseRef-scancode-intel-sample-source-code-2015"
+  - "LicenseRef-scancode-intel-scl"
+  - "LicenseRef-scancode-iozone"
+  - "LicenseRef-scancode-iptc-2006"
+  - "LicenseRef-scancode-iso-recorder"
+  - "LicenseRef-scancode-itunes"
+  - "LicenseRef-scancode-java-research-1.5"
+  - "LicenseRef-scancode-java-research-1.6"
+  - "LicenseRef-scancode-jboss-eula"
+  - "LicenseRef-scancode-jetbrains-toolbox-oss-3"
+  - "LicenseRef-scancode-jetty-ccla-1.1"
+  - "LicenseRef-scancode-jgraph-general"
+  - "LicenseRef-scancode-jmagnetic"
+  - "LicenseRef-scancode-jrunner"
+  - "LicenseRef-scancode-jsr-107-jcache-spec"
+  - "LicenseRef-scancode-jsr-107-jcache-spec-2013"
+  - "LicenseRef-scancode-katharos-0.1.0"
+  - "LicenseRef-scancode-kreative-relay-fonts-free-1.2f"
+  - "LicenseRef-scancode-larabie"
+  - "LicenseRef-scancode-leap-motion-sdk-2019"
+  - "LicenseRef-scancode-librato-exception"
+  - "LicenseRef-scancode-lontium-linux-firmware"
+  - "LicenseRef-scancode-lsi-proprietary-eula"
+  - "LicenseRef-scancode-lumisoft-mail-server"
+  - "LicenseRef-scancode-luxi"
+  - "LicenseRef-scancode-lyubinskiy-dropdown"
+  - "LicenseRef-scancode-lyubinskiy-popup-window"
+  - "LicenseRef-scancode-marvell-firmware"
+  - "LicenseRef-scancode-marvell-firmware-2019"
+  - "LicenseRef-scancode-mcafee-tou"
+  - "LicenseRef-scancode-mcrae-pl-4-r53"
+  - "LicenseRef-scancode-melange"
+  - "LicenseRef-scancode-metageek-inssider-eula"
+  - "LicenseRef-scancode-microchip-linux-firmware"
+  - "LicenseRef-scancode-microsoft-windows-rally-devkit"
+  - "LicenseRef-scancode-minecraft-mod"
+  - "LicenseRef-scancode-moxa-linux-firmware"
+  - "LicenseRef-scancode-mpeg-7"
+  - "LicenseRef-scancode-ms-asp-net-ajax-supp-terms"
+  - "LicenseRef-scancode-ms-asp-net-mvc3"
+  - "LicenseRef-scancode-ms-asp-net-mvc4"
+  - "LicenseRef-scancode-ms-asp-net-mvc4-extensions"
+  - "LicenseRef-scancode-ms-asp-net-software"
+  - "LicenseRef-scancode-ms-asp-net-tools-pre-release"
+  - "LicenseRef-scancode-ms-asp-net-web-optimization"
+  - "LicenseRef-scancode-ms-asp-net-web-pages-2"
+  - "LicenseRef-scancode-ms-asp-net-web-pages-templates"
+  - "LicenseRef-scancode-ms-azure-data-studio"
+  - "LicenseRef-scancode-ms-azure-spatialanchors-2.9.0"
+  - "LicenseRef-scancode-ms-capicom"
+  - "LicenseRef-scancode-ms-control-spy-2.0"
+  - "LicenseRef-scancode-ms-data-tier-af-2022"
+  - "LicenseRef-scancode-ms-dev-services-2018-06"
+  - "LicenseRef-scancode-ms-dev-services-agreement"
+  - "LicenseRef-scancode-ms-device-emulator-3.0"
+  - "LicenseRef-scancode-ms-direct3d-d3d120n7-1.1.0"
+  - "LicenseRef-scancode-ms-directx-sdk-eula"
+  - "LicenseRef-scancode-ms-dxsdk-d3dx-9.29.952.3"
+  - "LicenseRef-scancode-ms-enterprise-library-eula"
+  - "LicenseRef-scancode-ms-entity-framework-4.1"
+  - "LicenseRef-scancode-ms-entity-framework-5"
+  - "LicenseRef-scancode-ms-exchange-srv-2010-sp2-sdk"
+  - "LicenseRef-scancode-ms-iis-container-eula-2020"
+  - "LicenseRef-scancode-ms-ilmerge"
+  - "LicenseRef-scancode-ms-invisible-eula-1.0"
+  - "LicenseRef-scancode-ms-jdbc-driver-40-sql-server"
+  - "LicenseRef-scancode-ms-jdbc-driver-41-sql-server"
+  - "LicenseRef-scancode-ms-jdbc-driver-60-sql-server"
+  - "LicenseRef-scancode-ms-kinext-win-sdk"
+  - "LicenseRef-scancode-ms-limited-community"
+  - "LicenseRef-scancode-ms-msn-webgrease"
+  - "LicenseRef-scancode-ms-net-framework-4-supp-terms"
+  - "LicenseRef-scancode-ms-net-library"
+  - "LicenseRef-scancode-ms-net-library-2016-05"
+  - "LicenseRef-scancode-ms-net-library-2018-11"
+  - "LicenseRef-scancode-ms-net-library-2019-06"
+  - "LicenseRef-scancode-ms-net-library-2020-09"
+  - "LicenseRef-scancode-ms-nuget"
+  - "LicenseRef-scancode-ms-nuget-package-manager"
+  - "LicenseRef-scancode-ms-office-extensible-file"
+  - "LicenseRef-scancode-ms-programsynthesis-7.22.0"
+  - "LicenseRef-scancode-ms-reactive-extensions-eula"
+  - "LicenseRef-scancode-ms-refl"
+  - "LicenseRef-scancode-ms-research-shared-source"
+  - "LicenseRef-scancode-ms-rsl"
+  - "LicenseRef-scancode-ms-silverlight-3"
+  - "LicenseRef-scancode-ms-sql-server-compact-4.0"
+  - "LicenseRef-scancode-ms-sql-server-data-tools"
+  - "LicenseRef-scancode-ms-testplatform-17.0.0"
+  - "LicenseRef-scancode-ms-typescript-msbuild-4.1.4"
+  - "LicenseRef-scancode-ms-visual-2008-runtime"
+  - "LicenseRef-scancode-ms-visual-2010-runtime"
+  - "LicenseRef-scancode-ms-visual-2015-sdk"
+  - "LicenseRef-scancode-ms-visual-cpp-2015-runtime"
+  - "LicenseRef-scancode-ms-visual-studio-code"
+  - "LicenseRef-scancode-ms-visual-studio-code-2018"
+  - "LicenseRef-scancode-ms-visual-studio-code-2022"
+  - "LicenseRef-scancode-ms-vs-addons-ext-17.2.0"
+  - "LicenseRef-scancode-ms-web-developer-tools-1.0"
+  - "LicenseRef-scancode-ms-win-container-eula-2020"
+  - "LicenseRef-scancode-ms-windows-driver-kit"
+  - "LicenseRef-scancode-ms-windows-identity-foundation"
+  - "LicenseRef-scancode-ms-windows-sdk-win7-net-4"
+  - "LicenseRef-scancode-ms-windows-server-2003-ddk"
+  - "LicenseRef-scancode-ms-windows-server-2003-sdk"
+  - "LicenseRef-scancode-ms-xamarin-uitest3.2.0"
+  - "LicenseRef-scancode-ms-xml-core-4.0"
+  - "LicenseRef-scancode-msppl"
+  - "LicenseRef-scancode-mtx-licensing-statement"
+  - "LicenseRef-scancode-netapp-sdk-aug2020"
+  - "LicenseRef-scancode-netronome-firmware"
+  - "LicenseRef-scancode-new-relic"
+  - "LicenseRef-scancode-non-violent-4.0"
+  - "LicenseRef-scancode-nvidia-apex-sdk-eula-2011"
+  - "LicenseRef-scancode-nvidia-cuda-supplement-2020"
+  - "LicenseRef-scancode-nvidia-isaac-eula-2019.1"
+  - "LicenseRef-scancode-nvidia-ngx-eula-2019"
+  - "LicenseRef-scancode-nvidia-sdk-eula-v0.11"
+  - "LicenseRef-scancode-nvidia-video-codec-agreement"
+  - "LicenseRef-scancode-nxp-firmware-patent"
+  - "LicenseRef-scancode-nxp-linux-firmware"
+  - "LicenseRef-scancode-nxp-mc-firmware"
+  - "LicenseRef-scancode-nxp-microctl-proprietary"
+  - "LicenseRef-scancode-nxp-warranty-disclaimer"
+  - "LicenseRef-scancode-oasis-ipr-2013"
+  - "LicenseRef-scancode-oasis-ipr-policy-2014"
+  - "LicenseRef-scancode-ocb-non-military-2013"
+  - "LicenseRef-scancode-ocb-open-source-2013"
+  - "LicenseRef-scancode-ocb-patent-openssl-2013"
+  - "LicenseRef-scancode-oculus-sdk-2020"
+  - "LicenseRef-scancode-oculus-sdk-3.5"
+  - "LicenseRef-scancode-ogc-document-2020"
+  - "LicenseRef-scancode-opennetcf-shared-source"
+  - "LicenseRef-scancode-openvpn-as-eula"
+  - "LicenseRef-scancode-opera-eula-2018"
+  - "LicenseRef-scancode-opera-eula-eea-2018"
+  - "LicenseRef-scancode-opera-widget-1.0"
+  - "LicenseRef-scancode-oracle-bcl-java-platform-2013"
+  - "LicenseRef-scancode-oracle-bcl-java-platform-2017"
+  - "LicenseRef-scancode-oracle-bcl-javaee"
+  - "LicenseRef-scancode-oracle-bcl-javase-javafx-2012"
+  - "LicenseRef-scancode-oracle-bcl-javase-javafx-2013"
+  - "LicenseRef-scancode-oracle-bcl-jsse-1.0.3"
+  - "LicenseRef-scancode-oracle-devtools-vsnet-dev"
+  - "LicenseRef-scancode-oracle-entitlement-05-15"
+  - "LicenseRef-scancode-oracle-java-ee-sdk-2010"
+  - "LicenseRef-scancode-oracle-nftc-2021"
+  - "LicenseRef-scancode-oracle-otn-javase-2019"
+  - "LicenseRef-scancode-oracle-sql-developer"
+  - "LicenseRef-scancode-oracle-web-sites-tou"
+  - "LicenseRef-scancode-osgi-spec-2.0"
+  - "LicenseRef-scancode-ossn-3.0"
+  - "LicenseRef-scancode-otn-dev-dist"
+  - "LicenseRef-scancode-otn-dev-dist-2009"
+  - "LicenseRef-scancode-otn-dev-dist-2014"
+  - "LicenseRef-scancode-otn-dev-dist-2016"
+  - "LicenseRef-scancode-otn-early-adopter-2018"
+  - "LicenseRef-scancode-otn-early-adopter-development"
+  - "LicenseRef-scancode-otn-standard-2014-09"
+  - "LicenseRef-scancode-owal-1.0"
+  - "LicenseRef-scancode-paint-net"
+  - "LicenseRef-scancode-passive-aggressive"
+  - "LicenseRef-scancode-pfe-proprietary-notice"
+  - "LicenseRef-scancode-pftus-1.1"
+  - "LicenseRef-scancode-pml-2020"
+  - "LicenseRef-scancode-polyform-strict-1.0.0"
+  - "LicenseRef-scancode-powervr-tools-software-eula"
+  - "LicenseRef-scancode-prosperity-1.0.1"
+  - "LicenseRef-scancode-qaplug"
+  - "LicenseRef-scancode-qca-linux-firmware"
+  - "LicenseRef-scancode-qca-technology"
+  - "LicenseRef-scancode-qlogic-firmware"
+  - "LicenseRef-scancode-qti-linux-firmware"
+  - "LicenseRef-scancode-quicktime"
+  - "LicenseRef-scancode-quin-street"
+  - "LicenseRef-scancode-ralink-firmware"
+  - "LicenseRef-scancode-rcsl-2.0"
+  - "LicenseRef-scancode-rcsl-3.0"
+  - "LicenseRef-scancode-realm-platform-extension-2017"
+  - "LicenseRef-scancode-red-hat-logos"
+  - "LicenseRef-scancode-red-hat-trademarks"
+  - "LicenseRef-scancode-rubyencoder-loader"
+  - "LicenseRef-scancode-safecopy-eula"
+  - "LicenseRef-scancode-san-francisco-font"
+  - "LicenseRef-scancode-sandeep"
+  - "LicenseRef-scancode-scilab-en"
+  - "LicenseRef-scancode-scilab-fr"
+  - "LicenseRef-scancode-scola-en"
+  - "LicenseRef-scancode-scola-fr"
+  - "LicenseRef-scancode-script-nikhilk"
+  - "LicenseRef-scancode-scrub"
+  - "LicenseRef-scancode-smartlabs-freeware"
+  - "LicenseRef-scancode-softerra-ldap-browser-eula"
+  - "LicenseRef-scancode-solace-software-eula-2020"
+  - "LicenseRef-scancode-spark-jive"
+  - "LicenseRef-scancode-splunk-3pp-eula"
+  - "LicenseRef-scancode-splunk-mint-tos-2018"
+  - "LicenseRef-scancode-squeak"
+  - "LicenseRef-scancode-srgb"
+  - "LicenseRef-scancode-st-mcd-2.0"
+  - "LicenseRef-scancode-stmicro-linux-firmware"
+  - "LicenseRef-scancode-sun-bcl-11-06"
+  - "LicenseRef-scancode-sun-bcl-11-07"
+  - "LicenseRef-scancode-sun-bcl-11-08"
+  - "LicenseRef-scancode-sun-bcl-j2re-1.2.x"
+  - "LicenseRef-scancode-sun-bcl-j2re-1.4.2"
+  - "LicenseRef-scancode-sun-bcl-j2re-1.4.x"
+  - "LicenseRef-scancode-sun-bcl-j2re-5.0"
+  - "LicenseRef-scancode-sun-bcl-java-servlet-imp-2.1.1"
+  - "LicenseRef-scancode-sun-bcl-javahelp"
+  - "LicenseRef-scancode-sun-bcl-jimi-sdk"
+  - "LicenseRef-scancode-sun-bcl-jre6"
+  - "LicenseRef-scancode-sun-bcl-jsmq"
+  - "LicenseRef-scancode-sun-bcl-opendmk"
+  - "LicenseRef-scancode-sun-bcl-openjdk"
+  - "LicenseRef-scancode-sun-bcl-sdk-1.3"
+  - "LicenseRef-scancode-sun-bcl-sdk-1.4.2"
+  - "LicenseRef-scancode-sun-bcl-sdk-5.0"
+  - "LicenseRef-scancode-sun-bcl-sdk-6.0"
+  - "LicenseRef-scancode-sun-bcl-web-start"
+  - "LicenseRef-scancode-sun-communications-api"
+  - "LicenseRef-scancode-sun-ejb-spec-2.1"
+  - "LicenseRef-scancode-sun-ejb-spec-3.0"
+  - "LicenseRef-scancode-sun-entitlement-03-15"
+  - "LicenseRef-scancode-sun-entitlement-jaf"
+  - "LicenseRef-scancode-sun-glassfish"
+  - "LicenseRef-scancode-sun-iiop"
+  - "LicenseRef-scancode-sun-java-transaction-api"
+  - "LicenseRef-scancode-sun-java-web-services-dev-1.6"
+  - "LicenseRef-scancode-sun-javamail"
+  - "LicenseRef-scancode-sun-jsr-spec-04-2006"
+  - "LicenseRef-scancode-sun-jta-spec-1.0.1"
+  - "LicenseRef-scancode-sun-jta-spec-1.0.1b"
+  - "LicenseRef-scancode-sun-project-x"
+  - "LicenseRef-scancode-sun-prop-non-commercial"
+  - "LicenseRef-scancode-sun-sdk-spec-1.1"
+  - "LicenseRef-scancode-taligent-jdk"
+  - "LicenseRef-scancode-tenable-nessus"
+  - "LicenseRef-scancode-ti-broadband-apps"
+  - "LicenseRef-scancode-ti-linux-firmware"
+  - "LicenseRef-scancode-tizen-sdk"
+  - "LicenseRef-scancode-treeview-developer"
+  - "LicenseRef-scancode-treeview-distributor"
+  - "LicenseRef-scancode-triptracker"
+  - "LicenseRef-scancode-uofu-rfpl"
+  - "LicenseRef-scancode-verisign"
+  - "LicenseRef-scancode-vitesse-prop"
+  - "LicenseRef-scancode-vs10x-code-map"
+  - "LicenseRef-scancode-vuforia-2013-07-29"
+  - "LicenseRef-scancode-wince-50-shared-source"
+  - "LicenseRef-scancode-wink"
+  - "LicenseRef-scancode-xceed-community-2021"
+  - "LicenseRef-scancode-yahoo-browserplus-eula"
+  - "LicenseRef-scancode-yahoo-messenger-eula"
+  - "LicenseRef-scancode-yolo-1.0"
+  - "LicenseRef-scancode-yolo-2.0"
+  - "LicenseRef-scancode-zhorn-stickies"
+  - "LicenseRef-scancode-zipeg"
+  - "SISSL"
+  - "SISSL-1.2"
+  - "Unicode-TOU"
+  - "Watcom-1.0"
+  patent-license:
+  - "LicenseRef-scancode-adobe-dng-spec-patent"
+  - "LicenseRef-scancode-cncf-corporate-cla-1.0"
+  - "LicenseRef-scancode-cncf-individual-cla-1.0"
+  - "LicenseRef-scancode-facebook-patent-rights-2"
+  - "LicenseRef-scancode-freetype-patent"
+  - "LicenseRef-scancode-google-cla"
+  - "LicenseRef-scancode-google-corporate-cla"
+  - "LicenseRef-scancode-google-patent-license"
+  - "LicenseRef-scancode-google-patent-license-fuchsia"
+  - "LicenseRef-scancode-google-patent-license-fuschia"
+  - "LicenseRef-scancode-google-patent-license-golang"
+  - "LicenseRef-scancode-google-patent-license-webm"
+  - "LicenseRef-scancode-google-patent-license-webrtc"
+  - "LicenseRef-scancode-mozilla-ospl-1.0"
+  - "LicenseRef-scancode-ms-cla"
+  - "LicenseRef-scancode-ms-patent-promise"
+  - "LicenseRef-scancode-ms-patent-promise-mono"
+  - "LicenseRef-scancode-owf-cla-1.0-copyright-patent"
+  - "LicenseRef-scancode-owfa-1.0"
+  - "LicenseRef-scancode-owfa-1.0-patent-only"
+  - "LicenseRef-scancode-square-cla"
+  commercial:
+  - "LicenseRef-scancode-adobe-eula"
+  - "LicenseRef-scancode-adobe-general-tou"
+  - "LicenseRef-scancode-agentxpp"
+  - "LicenseRef-scancode-altova-eula"
+  - "LicenseRef-scancode-broadcom-commercial"
+  - "LicenseRef-scancode-broadcom-confidential"
+  - "LicenseRef-scancode-broadcom-standard-terms"
+  - "LicenseRef-scancode-broadcom-unpublished-source"
+  - "LicenseRef-scancode-com-oreilly-servlet"
+  - "LicenseRef-scancode-crashlytics-agreement-2018"
+  - "LicenseRef-scancode-cubiware-software-1.0"
+  - "LicenseRef-scancode-digia-qt-commercial"
+  - "LicenseRef-scancode-digia-qt-preview"
+  - "LicenseRef-scancode-dynarch-developer"
+  - "LicenseRef-scancode-egrappler"
+  - "LicenseRef-scancode-ej-technologies-eula"
+  - "LicenseRef-scancode-esri"
+  - "LicenseRef-scancode-excelsior-jet-runtime"
+  - "LicenseRef-scancode-fabric-agreement-2017"
+  - "LicenseRef-scancode-genivia-gsoap"
+  - "LicenseRef-scancode-gitlab-ee"
+  - "LicenseRef-scancode-helios-eula"
+  - "LicenseRef-scancode-here-proprietary"
+  - "LicenseRef-scancode-hp-proliant-essentials"
+  - "LicenseRef-scancode-ibm-data-server-2011"
+  - "LicenseRef-scancode-ibm-jre"
+  - "LicenseRef-scancode-infonode-1.1"
+  - "LicenseRef-scancode-intel-confidential"
+  - "LicenseRef-scancode-intel-material"
+  - "LicenseRef-scancode-irfanview-eula"
+  - "LicenseRef-scancode-isotope-cla"
+  - "LicenseRef-scancode-itc-eula"
+  - "LicenseRef-scancode-jetbrains-purchase-terms"
+  - "LicenseRef-scancode-jide-sla"
+  - "LicenseRef-scancode-lavantech"
+  - "LicenseRef-scancode-linotype-eula"
+  - "LicenseRef-scancode-mapbox-tos-2021"
+  - "LicenseRef-scancode-ms-eula-win-script-host"
+  - "LicenseRef-scancode-ms-net-framework-deployment"
+  - "LicenseRef-scancode-ms-nt-resource-kit"
+  - "LicenseRef-scancode-ms-office-system-programs-eula"
+  - "LicenseRef-scancode-ms-platform-sdk"
+  - "LicenseRef-scancode-ms-python-vscode-pylance-2021"
+  - "LicenseRef-scancode-ms-remote-ndis-usb-kit"
+  - "LicenseRef-scancode-ms-sysinternals-sla"
+  - "LicenseRef-scancode-ms-ttf-eula"
+  - "LicenseRef-scancode-ms-visual-studio-2017"
+  - "LicenseRef-scancode-ms-visual-studio-2017-tools"
+  - "LicenseRef-scancode-ms-win-sdk-server-2008-net-3.5"
+  - "LicenseRef-scancode-ms-windows-os-2018"
+  - "LicenseRef-scancode-ms-windows-sdk-win10"
+  - "LicenseRef-scancode-nero-eula"
+  - "LicenseRef-scancode-nexb-eula-saas-1.1.0"
+  - "LicenseRef-scancode-nexb-ssla-1.1.0"
+  - "LicenseRef-scancode-northwoods-sla-2021"
+  - "LicenseRef-scancode-numerical-recipes-notice"
+  - "LicenseRef-scancode-oracle-commercial-db-11g2"
+  - "LicenseRef-scancode-oracle-master-agreement"
+  - "LicenseRef-scancode-oxygen-xml-webhelp-eula"
+  - "LicenseRef-scancode-pdf-creator-pilot"
+  - "LicenseRef-scancode-philips-proprietary-notice2000"
+  - "LicenseRef-scancode-pivotal-tou"
+  - "LicenseRef-scancode-qt-commercial-1.1"
+  - "LicenseRef-scancode-rar-winrar-eula"
+  - "LicenseRef-scancode-rogue-wave"
+  - "LicenseRef-scancode-rsa-proprietary"
+  - "LicenseRef-scancode-rubyencoder-commercial"
+  - "LicenseRef-scancode-sencha-commercial"
+  - "LicenseRef-scancode-sencha-commercial-3.17"
+  - "LicenseRef-scancode-sencha-commercial-3.9"
+  - "LicenseRef-scancode-shavlik-eula"
+  - "LicenseRef-scancode-slysoft-eula"
+  - "LicenseRef-scancode-snmp4j-smi"
+  - "LicenseRef-scancode-splunk-sla"
+  - "LicenseRef-scancode-sun-proprietary-jdk"
+  - "LicenseRef-scancode-tanuki-development"
+  - "LicenseRef-scancode-tanuki-maintenance"
+  - "LicenseRef-scancode-teamdev-services"
+  - "LicenseRef-scancode-telerik-eula"
+  - "LicenseRef-scancode-ti-restricted"
+  - "LicenseRef-scancode-vicomsoft-software"
+  - "LicenseRef-scancode-vnc-viewer-ios"
+  - "LicenseRef-scancode-wifi-alliance"
+  - "LicenseRef-scancode-windriver-commercial"
+  - "LicenseRef-scancode-winzip-eula"
+  - "LicenseRef-scancode-winzip-self-extractor"
+  - "LicenseRef-scancode-xming"
+  - "LicenseRef-scancode-zapatec-calendar"
+  - "LicenseRef-scancode-ziplist5-geocode-dup-addendum"
+  - "LicenseRef-scancode-ziplist5-geocode-enterprise"
+  - "LicenseRef-scancode-ziplist5-geocode-workstation"
+  unstated-license:
+  - "LicenseRef-scancode-biosl-4.0"
+  - "LicenseRef-scancode-etalab-2.0-fr"
+  - "LicenseRef-scancode-here-disclaimer"
+  - "LicenseRef-scancode-newton-king-cla"
+  - "LicenseRef-scancode-no-license"
+  - "LicenseRef-scancode-trademark-notice"
+  generic:
+  - "LicenseRef-scancode-commercial-license"
+  - "LicenseRef-scancode-commercial-option"
+  - "LicenseRef-scancode-generic-cla"
+  - "LicenseRef-scancode-generic-export-compliance"
+  - "LicenseRef-scancode-generic-tos"
+  - "LicenseRef-scancode-generic-trademark"
+  - "LicenseRef-scancode-other-copyleft"
+  - "LicenseRef-scancode-other-permissive"
+  - "LicenseRef-scancode-proprietary"
+  - "LicenseRef-scancode-proprietary-license"
+  - "LicenseRef-scancode-public-domain"
+  - "LicenseRef-scancode-public-domain-disclaimer"
+  - "LicenseRef-scancode-unpublished-source"
+  - "LicenseRef-scancode-us-govt-public-domain"
+  - "LicenseRef-scancode-warranty-disclaimer"
+  unknown:
+  - "LicenseRef-scancode-free-unknown"
+  - "LicenseRef-scancode-license-file-reference"
+  - "LicenseRef-scancode-see-license"
+  - "LicenseRef-scancode-unknown"
+  - "LicenseRef-scancode-unknown-license-reference"
+  - "LicenseRef-scancode-unknown-spdx"
+categories_by_license:
+  "0BSD":
+  - "permissive"
+  AAL:
+  - "permissive"
+  ADSL:
+  - "permissive"
+  AFL-1.1:
+  - "permissive"
+  AFL-1.2:
+  - "permissive"
+  AFL-2.0:
+  - "permissive"
+  AFL-2.1:
+  - "permissive"
+  AFL-3.0:
+  - "permissive"
+  AGPL-1.0-only:
+  - "copyleft"
+  AGPL-1.0-or-later:
+  - "copyleft"
+  AGPL-3.0-only:
+  - "copyleft"
+  AGPL-3.0-or-later:
+  - "copyleft"
+  AMDPLPA:
+  - "permissive"
+  AML:
+  - "permissive"
+  AMPAS:
+  - "permissive"
+  ANTLR-PD:
+  - "permissive"
+  ANTLR-PD-fallback:
+  - "public-domain"
+  APAFML:
+  - "permissive"
+  APL-1.0:
+  - "copyleft"
+  APSL-1.0:
+  - "copyleft-limited"
+  APSL-1.1:
+  - "copyleft-limited"
+  APSL-1.2:
+  - "copyleft-limited"
+  APSL-2.0:
+  - "copyleft-limited"
+  Abstyles:
+  - "permissive"
+  Adobe-2006:
+  - "permissive"
+  Adobe-Glyph:
+  - "permissive"
+  Afmparse:
+  - "permissive"
+  Aladdin:
+  - "copyleft"
+  Apache-1.0:
+  - "permissive"
+  Apache-1.1:
+  - "permissive"
+  Apache-2.0:
+  - "permissive"
+  App-s2p:
+  - "permissive"
+  Arphic-1999:
+  - "copyleft"
+  Artistic-1.0:
+  - "copyleft-limited"
+  Artistic-1.0-Perl:
+  - "copyleft-limited"
+  Artistic-1.0-cl8:
+  - "copyleft-limited"
+  Artistic-2.0:
+  - "copyleft-limited"
+  BSD-1-Clause:
+  - "permissive"
+  BSD-2-Clause:
+  - "permissive"
+  BSD-2-Clause-Patent:
+  - "permissive"
+  BSD-2-Clause-Views:
+  - "permissive"
+  BSD-3-Clause:
+  - "permissive"
+  BSD-3-Clause-Attribution:
+  - "permissive"
+  BSD-3-Clause-Clear:
+  - "permissive"
+  BSD-3-Clause-LBNL:
+  - "permissive"
+  BSD-3-Clause-Modification:
+  - "permissive"
+  BSD-3-Clause-No-Military-License:
+  - "free-restricted"
+  BSD-3-Clause-No-Nuclear-License:
+  - "free-restricted"
+  BSD-3-Clause-No-Nuclear-License-2014:
+  - "free-restricted"
+  BSD-3-Clause-No-Nuclear-Warranty:
+  - "free-restricted"
+  BSD-3-Clause-Open-MPI:
+  - "permissive"
+  BSD-4-Clause:
+  - "permissive"
+  BSD-4-Clause-Shortened:
+  - "permissive"
+  BSD-4-Clause-UC:
+  - "permissive"
+  BSD-Protection:
+  - "copyleft"
+  BSD-Source-Code:
+  - "permissive"
+  BSL-1.0:
+  - "permissive"
+  BUSL-1.1:
+  - "source-available"
+  Baekmuk:
+  - "permissive"
+  Bahyph:
+  - "permissive"
+  Barr:
+  - "permissive"
+  Beerware:
+  - "permissive"
+  BitTorrent-1.0:
+  - "copyleft-limited"
+  BitTorrent-1.1:
+  - "copyleft-limited"
+  Bitstream-Vera:
+  - "permissive"
+  BlueOak-1.0.0:
+  - "permissive"
+  Borceux:
+  - "permissive"
+  C-UDA-1.0:
+  - "free-restricted"
+  CAL-1.0:
+  - "copyleft"
+  CAL-1.0-Combined-Work-Exception:
+  - "copyleft-limited"
+  CATOSL-1.1:
+  - "copyleft-limited"
+  CC-BY-1.0:
+  - "permissive"
+  CC-BY-2.0:
+  - "permissive"
+  CC-BY-2.5:
+  - "permissive"
+  CC-BY-2.5-AU:
+  - "permissive"
+  CC-BY-3.0:
+  - "permissive"
+  CC-BY-3.0-AT:
+  - "permissive"
+  CC-BY-3.0-DE:
+  - "permissive"
+  CC-BY-3.0-NL:
+  - "permissive"
+  CC-BY-3.0-US:
+  - "permissive"
+  CC-BY-4.0:
+  - "permissive"
+  CC-BY-NC-1.0:
+  - "source-available"
+  CC-BY-NC-2.0:
+  - "source-available"
+  CC-BY-NC-2.5:
+  - "source-available"
+  CC-BY-NC-3.0:
+  - "source-available"
+  CC-BY-NC-3.0-DE:
+  - "free-restricted"
+  CC-BY-NC-4.0:
+  - "source-available"
+  CC-BY-NC-ND-1.0:
+  - "source-available"
+  CC-BY-NC-ND-2.0:
+  - "source-available"
+  CC-BY-NC-ND-2.5:
+  - "source-available"
+  CC-BY-NC-ND-3.0:
+  - "source-available"
+  CC-BY-NC-ND-3.0-DE:
+  - "free-restricted"
+  CC-BY-NC-ND-3.0-IGO:
+  - "source-available"
+  CC-BY-NC-ND-4.0:
+  - "source-available"
+  CC-BY-NC-SA-1.0:
+  - "source-available"
+  CC-BY-NC-SA-2.0:
+  - "source-available"
+  CC-BY-NC-SA-2.0-FR:
+  - "source-available"
+  CC-BY-NC-SA-2.0-UK:
+  - "source-available"
+  CC-BY-NC-SA-2.5:
+  - "source-available"
+  CC-BY-NC-SA-3.0:
+  - "source-available"
+  CC-BY-NC-SA-3.0-DE:
+  - "source-available"
+  CC-BY-NC-SA-3.0-IGO:
+  - "source-available"
+  CC-BY-NC-SA-4.0:
+  - "source-available"
+  CC-BY-ND-1.0:
+  - "source-available"
+  CC-BY-ND-2.0:
+  - "source-available"
+  CC-BY-ND-2.5:
+  - "source-available"
+  CC-BY-ND-3.0:
+  - "source-available"
+  CC-BY-ND-3.0-DE:
+  - "free-restricted"
+  CC-BY-ND-4.0:
+  - "source-available"
+  CC-BY-SA-1.0:
+  - "copyleft-limited"
+  CC-BY-SA-2.0:
+  - "copyleft-limited"
+  CC-BY-SA-2.0-UK:
+  - "copyleft-limited"
+  CC-BY-SA-2.1-JP:
+  - "copyleft-limited"
+  CC-BY-SA-2.5:
+  - "copyleft-limited"
+  CC-BY-SA-3.0:
+  - "copyleft-limited"
+  CC-BY-SA-3.0-AT:
+  - "copyleft-limited"
+  CC-BY-SA-3.0-DE:
+  - "copyleft-limited"
+  CC-BY-SA-4.0:
+  - "copyleft-limited"
+  CC-PDDC:
+  - "public-domain"
+  CC0-1.0:
+  - "public-domain"
+  CDDL-1.0:
+  - "copyleft-limited"
+  CDDL-1.1:
+  - "copyleft-limited"
+  CDL-1.0:
+  - "copyleft-limited"
+  CDLA-Permissive-1.0:
+  - "permissive"
+  CDLA-Permissive-2.0:
+  - "permissive"
+  CDLA-Sharing-1.0:
+  - "copyleft-limited"
+  CECILL-1.0:
+  - "copyleft"
+  CECILL-1.1:
+  - "copyleft-limited"
+  CECILL-2.0:
+  - "copyleft-limited"
+  CECILL-2.1:
+  - "copyleft-limited"
+  CECILL-B:
+  - "permissive"
+  CECILL-C:
+  - "copyleft"
+  CERN-OHL-1.1:
+  - "permissive"
+  CERN-OHL-1.2:
+  - "permissive"
+  CERN-OHL-P-2.0:
+  - "permissive"
+  CERN-OHL-S-2.0:
+  - "copyleft"
+  CERN-OHL-W-2.0:
+  - "copyleft-limited"
+  CNRI-Jython:
+  - "permissive"
+  CNRI-Python:
+  - "permissive"
+  CNRI-Python-GPL-Compatible:
+  - "permissive"
+  COIL-1.0:
+  - "permissive"
+  CPAL-1.0:
+  - "copyleft"
+  CPL-1.0:
+  - "copyleft-limited"
+  CPOL-1.02:
+  - "free-restricted"
+  CUA-OPL-1.0:
+  - "copyleft-limited"
+  Caldera:
+  - "permissive"
+  ClArtistic:
+  - "copyleft-limited"
+  Community-Spec-1.0:
+  - "permissive"
+  Condor-1.1:
+  - "permissive"
+  Crossword:
+  - "permissive"
+  CrystalStacker:
+  - "permissive"
+  Cube:
+  - "permissive"
+  D-FSL-1.0:
+  - "copyleft"
+  DL-DE-BY-2.0:
+  - "permissive"
+  DOC:
+  - "permissive"
+  DRL-1.0:
+  - "permissive"
+  DSDP:
+  - "permissive"
+  Dotseqn:
+  - "permissive"
+  ECL-1.0:
+  - "permissive"
+  ECL-2.0:
+  - "permissive"
+  EFL-1.0:
+  - "permissive"
+  EFL-2.0:
+  - "permissive"
+  EPICS:
+  - "permissive"
+  EPL-1.0:
+  - "copyleft-limited"
+  EPL-2.0:
+  - "copyleft-limited"
+  EUDatagrid:
+  - "permissive"
+  EUPL-1.0:
+  - "copyleft"
+  EUPL-1.1:
+  - "copyleft-limited"
+  EUPL-1.2:
+  - "copyleft-limited"
+  Elastic-2.0:
+  - "source-available"
+  Entessa:
+  - "permissive"
+  ErlPL-1.1:
+  - "copyleft"
+  Eurosym:
+  - "copyleft-limited"
+  FDK-AAC:
+  - "copyleft-limited"
+  FSFAP:
+  - "permissive"
+  FSFUL:
+  - "public-domain"
+  FSFULLR:
+  - "permissive"
+  FTL:
+  - "permissive"
+  Fair:
+  - "permissive"
+  Frameworx-1.0:
+  - "copyleft-limited"
+  FreeBSD-DOC:
+  - "permissive"
+  FreeImage:
+  - "copyleft-limited"
+  GD:
+  - "permissive"
+  GFDL-1.1-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.1-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.1-no-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.1-no-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.1-only:
+  - "copyleft-limited"
+  GFDL-1.1-or-later:
+  - "copyleft-limited"
+  GFDL-1.2-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.2-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.2-no-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.2-no-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.2-only:
+  - "copyleft-limited"
+  GFDL-1.2-or-later:
+  - "copyleft-limited"
+  GFDL-1.3-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.3-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.3-no-invariants-only:
+  - "copyleft-limited"
+  GFDL-1.3-no-invariants-or-later:
+  - "copyleft-limited"
+  GFDL-1.3-only:
+  - "copyleft-limited"
+  GFDL-1.3-or-later:
+  - "copyleft-limited"
+  GL2PS:
+  - "copyleft-limited"
+  GLWTPL:
+  - "permissive"
+  GPL-1.0-only:
+  - "copyleft"
+  GPL-1.0-or-later:
+  - "copyleft"
+  GPL-2.0-only:
+  - "copyleft"
+  GPL-2.0-or-later:
+  - "copyleft"
+  GPL-3.0-only:
+  - "copyleft"
+  GPL-3.0-or-later:
+  - "copyleft"
+  Giftware:
+  - "permissive"
+  Glide:
+  - "copyleft"
+  Glulxe:
+  - "permissive"
+  HPND:
+  - "permissive"
+  HPND-sell-variant:
+  - "permissive"
+  HTMLTIDY:
+  - "permissive"
+  HaskellReport:
+  - "permissive"
+  Hippocratic-2.1:
+  - "free-restricted"
+  IBM-pibs:
+  - "permissive"
+  ICU:
+  - "permissive"
+  IJG:
+  - "permissive"
+  IPA:
+  - "copyleft-limited"
+  IPL-1.0:
+  - "copyleft-limited"
+  ISC:
+  - "permissive"
+  ImageMagick:
+  - "permissive"
+  Imlib2:
+  - "copyleft-limited"
+  Info-ZIP:
+  - "permissive"
+  Intel:
+  - "permissive"
+  Intel-ACPI:
+  - "permissive"
+  Interbase-1.0:
+  - "copyleft"
+  JPNIC:
+  - "permissive"
+  JSON:
+  - "permissive"
+  Jam:
+  - "permissive"
+  JasPer-2.0:
+  - "permissive"
+  KiCad-libraries-exception:
+  - "copyleft-limited"
+  LAL-1.2:
+  - "copyleft"
+  LAL-1.3:
+  - "copyleft"
+  LGPL-2.0-only:
+  - "copyleft-limited"
+  LGPL-2.0-or-later:
+  - "copyleft-limited"
+  LGPL-2.1-only:
+  - "copyleft-limited"
+  LGPL-2.1-or-later:
+  - "copyleft-limited"
+  LGPL-3.0-only:
+  - "copyleft-limited"
+  LGPL-3.0-or-later:
+  - "copyleft-limited"
+  LGPLLR:
+  - "copyleft-limited"
+  LPL-1.0:
+  - "copyleft-limited"
+  LPL-1.02:
+  - "copyleft-limited"
+  LPPL-1.0:
+  - "copyleft"
+  LPPL-1.1:
+  - "copyleft"
+  LPPL-1.2:
+  - "copyleft"
+  LPPL-1.3a:
+  - "copyleft"
+  LPPL-1.3c:
+  - "copyleft"
+  Latex2e:
+  - "permissive"
+  Leptonica:
+  - "permissive"
+  LiLiQ-P-1.1:
+  - "copyleft-limited"
+  LiLiQ-R-1.1:
+  - "copyleft-limited"
+  LiLiQ-Rplus-1.1:
+  - "copyleft"
+  Libpng:
+  - "permissive"
+  LicenseRef-.amazon.com.-AmznSL-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-3com-microcode:
+  - "permissive"
+  LicenseRef-scancode-3dslicer-1.0:
+  - "permissive"
+  LicenseRef-scancode-4suite-1.1:
+  - "permissive"
+  LicenseRef-scancode-996-icu-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-Hippocratic-3.0:
+  - "free-restricted"
+  LicenseRef-scancode-abrms:
+  - "proprietary-free"
+  LicenseRef-scancode-ac3filter:
+  - "copyleft"
+  LicenseRef-scancode-accellera-systemc:
+  - "permissive"
+  LicenseRef-scancode-acroname-bdk:
+  - "proprietary-free"
+  LicenseRef-scancode-activestate-community:
+  - "proprietary-free"
+  LicenseRef-scancode-activestate-community-2012:
+  - "proprietary-free"
+  LicenseRef-scancode-activestate-komodo-edit:
+  - "proprietary-free"
+  LicenseRef-scancode-actuate-birt-ihub-ftype-sla:
+  - "proprietary-free"
+  LicenseRef-scancode-adaptec-downloadable:
+  - "proprietary-free"
+  LicenseRef-scancode-adaptec-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-addthis-mobile-sdk-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-adi-bsd:
+  - "permissive"
+  LicenseRef-scancode-adobe-acrobat-reader-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-air-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-air-sdk-2014:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-color-profile-bundling:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-color-profile-license:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-dng-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-dng-spec-patent:
+  - "patent-license"
+  LicenseRef-scancode-adobe-eula:
+  - "commercial"
+  LicenseRef-scancode-adobe-flash-player-eula-21.0:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-flex-4-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-flex-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-general-tou:
+  - "commercial"
+  LicenseRef-scancode-adobe-indesign-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-adobe-postscript:
+  - "proprietary-free"
+  LicenseRef-scancode-adrian:
+  - "permissive"
+  LicenseRef-scancode-aes-128-3.0:
+  - "public-domain"
+  LicenseRef-scancode-afpl-9.0:
+  - "copyleft"
+  LicenseRef-scancode-agentxpp:
+  - "commercial"
+  LicenseRef-scancode-agere-bsd:
+  - "permissive"
+  LicenseRef-scancode-agere-sla:
+  - "proprietary-free"
+  LicenseRef-scancode-ago-private-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-agpl-2.0:
+  - "copyleft"
+  LicenseRef-scancode-aladdin-md5:
+  - "permissive"
+  LicenseRef-scancode-alasir:
+  - "proprietary-free"
+  LicenseRef-scancode-alexisisaac-freeware:
+  - "permissive"
+  LicenseRef-scancode-allen-institute-software-2018:
+  - "free-restricted"
+  LicenseRef-scancode-altermime:
+  - "copyleft-limited"
+  LicenseRef-scancode-altova-eula:
+  - "commercial"
+  LicenseRef-scancode-amazon-redshift-jdbc:
+  - "proprietary-free"
+  LicenseRef-scancode-amd-historical:
+  - "permissive"
+  LicenseRef-scancode-amd-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-amd-linux-firmware-export:
+  - "proprietary-free"
+  LicenseRef-scancode-amlogic-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-ams-fonts:
+  - "permissive"
+  LicenseRef-scancode-android-sdk-2009:
+  - "proprietary-free"
+  LicenseRef-scancode-android-sdk-2012:
+  - "proprietary-free"
+  LicenseRef-scancode-android-sdk-2021:
+  - "proprietary-free"
+  LicenseRef-scancode-android-sdk-license:
+  - "proprietary-free"
+  LicenseRef-scancode-android-sdk-preview-2015:
+  - "proprietary-free"
+  LicenseRef-scancode-anepokis-1.0:
+  - "copyleft"
+  LicenseRef-scancode-anti-capitalist-1.4:
+  - "free-restricted"
+  LicenseRef-scancode-anu-license:
+  - "permissive"
+  LicenseRef-scancode-aop-pd:
+  - "public-domain"
+  LicenseRef-scancode-apache-due-credit:
+  - "permissive"
+  LicenseRef-scancode-apl-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-appfire-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-apple-attribution:
+  - "permissive"
+  LicenseRef-scancode-apple-attribution-1997:
+  - "permissive"
+  LicenseRef-scancode-apple-excl:
+  - "permissive"
+  LicenseRef-scancode-apple-mfi-license:
+  - "proprietary-free"
+  LicenseRef-scancode-apple-mpeg-4:
+  - "free-restricted"
+  LicenseRef-scancode-apple-sscl:
+  - "permissive"
+  LicenseRef-scancode-appsflyer-framework:
+  - "proprietary-free"
+  LicenseRef-scancode-aptana-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-arachni-psl-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-aravindan-premkumar:
+  - "permissive"
+  LicenseRef-scancode-argouml:
+  - "permissive"
+  LicenseRef-scancode-arm-cortex-mx:
+  - "proprietary-free"
+  LicenseRef-scancode-arm-llvm-sga:
+  - "permissive"
+  LicenseRef-scancode-array-input-method-pl:
+  - "permissive"
+  LicenseRef-scancode-artistic-1988-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-aslp:
+  - "free-restricted"
+  LicenseRef-scancode-aslr:
+  - "copyleft"
+  LicenseRef-scancode-asmus:
+  - "permissive"
+  LicenseRef-scancode-asn1:
+  - "permissive"
+  LicenseRef-scancode-ati-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-atkinson-hyperlegible-font:
+  - "permissive"
+  LicenseRef-scancode-atlassian-marketplace-tou:
+  - "proprietary-free"
+  LicenseRef-scancode-atmel-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-atmel-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-atmel-microcontroller:
+  - "proprietary-free"
+  LicenseRef-scancode-atmosphere-0.4:
+  - "source-available"
+  LicenseRef-scancode-autoit-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-bakoma-fonts-1995:
+  - "permissive"
+  LicenseRef-scancode-bapl-1.0:
+  - "source-available"
+  LicenseRef-scancode-bea-2.1:
+  - "permissive"
+  LicenseRef-scancode-beal-screamer:
+  - "permissive"
+  LicenseRef-scancode-bigdigits:
+  - "permissive"
+  LicenseRef-scancode-bigelow-holmes:
+  - "permissive"
+  LicenseRef-scancode-binary-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-binary-linux-firmware-patent:
+  - "proprietary-free"
+  LicenseRef-scancode-biopython:
+  - "permissive"
+  LicenseRef-scancode-biosl-4.0:
+  - "unstated-license"
+  LicenseRef-scancode-bittorrent-1.2:
+  - "copyleft-limited"
+  LicenseRef-scancode-bittorrent-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-bitwarden-1.0:
+  - "source-available"
+  LicenseRef-scancode-bitzi-pd:
+  - "permissive"
+  LicenseRef-scancode-blas-2017:
+  - "permissive"
+  LicenseRef-scancode-blitz-artistic:
+  - "copyleft-limited"
+  LicenseRef-scancode-bloomberg-blpapi:
+  - "proprietary-free"
+  LicenseRef-scancode-bohl-0.2:
+  - "permissive"
+  LicenseRef-scancode-boost-original:
+  - "permissive"
+  LicenseRef-scancode-bpel4ws-spec:
+  - "proprietary-free"
+  LicenseRef-scancode-bpmn-io:
+  - "permissive"
+  LicenseRef-scancode-brad-martinez-vb-32:
+  - "free-restricted"
+  LicenseRef-scancode-brent-corkum:
+  - "permissive"
+  LicenseRef-scancode-brian-clapper:
+  - "permissive"
+  LicenseRef-scancode-brian-gladman:
+  - "permissive"
+  LicenseRef-scancode-brian-gladman-3-clause:
+  - "permissive"
+  LicenseRef-scancode-brian-gladman-dual:
+  - "permissive"
+  LicenseRef-scancode-broadcom-cfe:
+  - "permissive"
+  LicenseRef-scancode-broadcom-commercial:
+  - "commercial"
+  LicenseRef-scancode-broadcom-confidential:
+  - "commercial"
+  LicenseRef-scancode-broadcom-dual:
+  - "copyleft"
+  LicenseRef-scancode-broadcom-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-broadcom-linux-timer:
+  - "permissive"
+  LicenseRef-scancode-broadcom-proprietary:
+  - "proprietary-free"
+  LicenseRef-scancode-broadcom-raspberry-pi:
+  - "proprietary-free"
+  LicenseRef-scancode-broadcom-standard-terms:
+  - "commercial"
+  LicenseRef-scancode-broadcom-unpublished-source:
+  - "commercial"
+  LicenseRef-scancode-broadcom-wiced:
+  - "proprietary-free"
+  LicenseRef-scancode-broadleaf-fair-use:
+  - "proprietary-free"
+  LicenseRef-scancode-brocade-firmware:
+  - "permissive"
+  LicenseRef-scancode-bruno-podetti:
+  - "permissive"
+  LicenseRef-scancode-bsd-1-clause-build:
+  - "permissive"
+  LicenseRef-scancode-bsd-1988:
+  - "permissive"
+  LicenseRef-scancode-bsd-2-clause-freebsd:
+  - "permissive"
+  LicenseRef-scancode-bsd-2-clause-netbsd:
+  - "permissive"
+  LicenseRef-scancode-bsd-2-clause-plus-advertizing:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-devine:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-fda:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-jtag:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-no-change:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-no-trademark:
+  - "permissive"
+  LicenseRef-scancode-bsd-3-clause-sun:
+  - "permissive"
+  LicenseRef-scancode-bsd-ack-carrot2:
+  - "permissive"
+  LicenseRef-scancode-bsd-artwork:
+  - "permissive"
+  LicenseRef-scancode-bsd-atmel:
+  - "permissive"
+  LicenseRef-scancode-bsd-axis:
+  - "permissive"
+  LicenseRef-scancode-bsd-axis-nomod:
+  - "permissive"
+  LicenseRef-scancode-bsd-credit:
+  - "permissive"
+  LicenseRef-scancode-bsd-dpt:
+  - "permissive"
+  LicenseRef-scancode-bsd-export:
+  - "permissive"
+  LicenseRef-scancode-bsd-innosys:
+  - "permissive"
+  LicenseRef-scancode-bsd-intel:
+  - "permissive"
+  LicenseRef-scancode-bsd-mylex:
+  - "permissive"
+  LicenseRef-scancode-bsd-new-derivative:
+  - "permissive"
+  LicenseRef-scancode-bsd-new-nomod:
+  - "permissive"
+  LicenseRef-scancode-bsd-new-tcpdump:
+  - "permissive"
+  LicenseRef-scancode-bsd-no-disclaimer:
+  - "permissive"
+  LicenseRef-scancode-bsd-no-disclaimer-unmodified:
+  - "permissive"
+  LicenseRef-scancode-bsd-no-mod:
+  - "free-restricted"
+  LicenseRef-scancode-bsd-original-muscle:
+  - "permissive"
+  LicenseRef-scancode-bsd-original-uc-1986:
+  - "permissive"
+  LicenseRef-scancode-bsd-original-uc-1990:
+  - "permissive"
+  LicenseRef-scancode-bsd-original-voices:
+  - "permissive"
+  LicenseRef-scancode-bsd-plus-mod-notice:
+  - "permissive"
+  LicenseRef-scancode-bsd-simplified-darwin:
+  - "permissive"
+  LicenseRef-scancode-bsd-simplified-intel:
+  - "permissive"
+  LicenseRef-scancode-bsd-simplified-source:
+  - "permissive"
+  LicenseRef-scancode-bsd-top:
+  - "permissive"
+  LicenseRef-scancode-bsd-top-gpl-addition:
+  - "permissive"
+  LicenseRef-scancode-bsd-unchanged:
+  - "permissive"
+  LicenseRef-scancode-bsd-unmodified:
+  - "permissive"
+  LicenseRef-scancode-bsd-x11:
+  - "permissive"
+  LicenseRef-scancode-bsl-1.0:
+  - "source-available"
+  LicenseRef-scancode-bsla:
+  - "permissive"
+  LicenseRef-scancode-bsla-no-advert:
+  - "permissive"
+  LicenseRef-scancode-bugsense-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-bytemark:
+  - "permissive"
+  LicenseRef-scancode-bzip2-libbzip-1.0.5:
+  - "permissive"
+  LicenseRef-scancode-c-fsl-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-cadence-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-can-ogl-alberta-2.1:
+  - "permissive"
+  LicenseRef-scancode-can-ogl-british-columbia-2.0:
+  - "permissive"
+  LicenseRef-scancode-can-ogl-nova-scotia-1.0:
+  - "permissive"
+  LicenseRef-scancode-can-ogl-ontario-1.0:
+  - "permissive"
+  LicenseRef-scancode-can-ogl-toronto-1.0:
+  - "permissive"
+  LicenseRef-scancode-careware:
+  - "permissive"
+  LicenseRef-scancode-carnegie-mellon:
+  - "permissive"
+  LicenseRef-scancode-carnegie-mellon-contributors:
+  - "permissive"
+  LicenseRef-scancode-cavium-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-cavium-malloc:
+  - "permissive"
+  LicenseRef-scancode-cavium-targeted-hardware:
+  - "free-restricted"
+  LicenseRef-scancode-cc-by-2.0-uk:
+  - "permissive"
+  LicenseRef-scancode-cc-by-nc-nd-2.0-at:
+  - "free-restricted"
+  LicenseRef-scancode-cc-by-nc-nd-2.0-au:
+  - "source-available"
+  LicenseRef-scancode-cc-by-nc-sa-3.0-us:
+  - "source-available"
+  LicenseRef-scancode-cc-devnations-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-cc-gpl-2.0-pt:
+  - "copyleft"
+  LicenseRef-scancode-cc-lgpl-2.1-pt:
+  - "copyleft-limited"
+  LicenseRef-scancode-cc-nc-sampling-plus-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-cc-pdm-1.0:
+  - "public-domain"
+  LicenseRef-scancode-cc-sampling-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-cc-sampling-plus-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-cclrc:
+  - "free-restricted"
+  LicenseRef-scancode-ccrc-1.0:
+  - "copyleft"
+  LicenseRef-scancode-cecill-1.0-en:
+  - "copyleft"
+  LicenseRef-scancode-cecill-2.0-fr:
+  - "copyleft-limited"
+  LicenseRef-scancode-cecill-2.1-fr:
+  - "copyleft-limited"
+  LicenseRef-scancode-cecill-b-en:
+  - "permissive"
+  LicenseRef-scancode-cecill-c-en:
+  - "copyleft-limited"
+  LicenseRef-scancode-cern-attribution-1995:
+  - "permissive"
+  LicenseRef-scancode-cgic:
+  - "permissive"
+  LicenseRef-scancode-chartdirector-6.0:
+  - "proprietary-free"
+  LicenseRef-scancode-chelsio-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-chicken-dl-0.2:
+  - "permissive"
+  LicenseRef-scancode-chris-maunder:
+  - "permissive"
+  LicenseRef-scancode-chris-stoy:
+  - "permissive"
+  LicenseRef-scancode-christopher-velazquez:
+  - "proprietary-free"
+  LicenseRef-scancode-classic-vb:
+  - "permissive"
+  LicenseRef-scancode-classworlds:
+  - "permissive"
+  LicenseRef-scancode-clear-bsd-1-clause:
+  - "permissive"
+  LicenseRef-scancode-click-license:
+  - "permissive"
+  LicenseRef-scancode-cloudera-express:
+  - "proprietary-free"
+  LicenseRef-scancode-cmigemo:
+  - "proprietary-free"
+  LicenseRef-scancode-cmr-no:
+  - "permissive"
+  LicenseRef-scancode-cmu-computing-services:
+  - "permissive"
+  LicenseRef-scancode-cmu-mit:
+  - "permissive"
+  LicenseRef-scancode-cmu-simple:
+  - "permissive"
+  LicenseRef-scancode-cmu-template:
+  - "permissive"
+  LicenseRef-scancode-cncf-corporate-cla-1.0:
+  - "patent-license"
+  LicenseRef-scancode-cncf-individual-cla-1.0:
+  - "patent-license"
+  LicenseRef-scancode-cockroach:
+  - "source-available"
+  LicenseRef-scancode-code-credit-license-1.0.1:
+  - "permissive"
+  LicenseRef-scancode-codeguru-permissions:
+  - "permissive"
+  LicenseRef-scancode-codesourcery-2004:
+  - "permissive"
+  LicenseRef-scancode-codexia:
+  - "proprietary-free"
+  LicenseRef-scancode-cognitive-web-osl-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-colt:
+  - "free-restricted"
+  LicenseRef-scancode-com-oreilly-servlet:
+  - "commercial"
+  LicenseRef-scancode-commercial-license:
+  - "generic"
+  LicenseRef-scancode-commercial-option:
+  - "generic"
+  LicenseRef-scancode-commonj-timer:
+  - "permissive"
+  LicenseRef-scancode-compass:
+  - "permissive"
+  LicenseRef-scancode-componentace-jcraft:
+  - "permissive"
+  LicenseRef-scancode-concursive-pl-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-confluent-community-1.0:
+  - "source-available"
+  LicenseRef-scancode-cooperative-non-violent-4.0:
+  - "proprietary-free"
+  LicenseRef-scancode-copyheart:
+  - "public-domain"
+  LicenseRef-scancode-corporate-accountability-1.1:
+  - "proprietary-free"
+  LicenseRef-scancode-cosl:
+  - "permissive"
+  LicenseRef-scancode-cosli:
+  - "free-restricted"
+  LicenseRef-scancode-couchbase-community:
+  - "proprietary-free"
+  LicenseRef-scancode-couchbase-enterprise:
+  - "proprietary-free"
+  LicenseRef-scancode-cpl-0.5:
+  - "copyleft-limited"
+  LicenseRef-scancode-cpm-2022:
+  - "permissive"
+  LicenseRef-scancode-cpol-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-cpp-core-guidelines:
+  - "permissive"
+  LicenseRef-scancode-crapl-0.1:
+  - "proprietary-free"
+  LicenseRef-scancode-crashlytics-agreement-2018:
+  - "commercial"
+  LicenseRef-scancode-crcalc:
+  - "permissive"
+  LicenseRef-scancode-crypto-keys-redistribution:
+  - "copyleft"
+  LicenseRef-scancode-cryptopp:
+  - "permissive"
+  LicenseRef-scancode-csla:
+  - "free-restricted"
+  LicenseRef-scancode-csprng:
+  - "permissive"
+  LicenseRef-scancode-ctl-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-cubiware-software-1.0:
+  - "commercial"
+  LicenseRef-scancode-cups:
+  - "copyleft"
+  LicenseRef-scancode-cve-tou:
+  - "permissive"
+  LicenseRef-scancode-cvwl:
+  - "proprietary-free"
+  LicenseRef-scancode-cwe-tou:
+  - "permissive"
+  LicenseRef-scancode-cximage:
+  - "permissive"
+  LicenseRef-scancode-cypress-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-d-fsl-1.0-en:
+  - "copyleft"
+  LicenseRef-scancode-d-zlib:
+  - "permissive"
+  LicenseRef-scancode-damail:
+  - "permissive"
+  LicenseRef-scancode-dante-treglia:
+  - "permissive"
+  LicenseRef-scancode-datamekanix-license:
+  - "permissive"
+  LicenseRef-scancode-day-spec:
+  - "proprietary-free"
+  LicenseRef-scancode-dbad:
+  - "proprietary-free"
+  LicenseRef-scancode-dbad-1.1:
+  - "permissive"
+  LicenseRef-scancode-dbcl-1.0:
+  - "copyleft"
+  LicenseRef-scancode-dco-1.1:
+  - "permissive"
+  LicenseRef-scancode-defensive-patent-1.1:
+  - "copyleft"
+  LicenseRef-scancode-dejavu-font:
+  - "permissive"
+  LicenseRef-scancode-delorie-historical:
+  - "permissive"
+  LicenseRef-scancode-dennis-ferguson:
+  - "free-restricted"
+  LicenseRef-scancode-devblocks-1.0:
+  - "copyleft"
+  LicenseRef-scancode-dgraph-cla:
+  - "source-available"
+  LicenseRef-scancode-dhtmlab-public:
+  - "permissive"
+  LicenseRef-scancode-digia-qt-commercial:
+  - "commercial"
+  LicenseRef-scancode-digia-qt-preview:
+  - "commercial"
+  LicenseRef-scancode-divx-open-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-divx-open-2.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-dl-de-by-1-0-de:
+  - "permissive"
+  LicenseRef-scancode-dl-de-by-1-0-en:
+  - "permissive"
+  LicenseRef-scancode-dl-de-by-2-0-en:
+  - "permissive"
+  LicenseRef-scancode-dl-de-by-nc-1-0-de:
+  - "free-restricted"
+  LicenseRef-scancode-dl-de-by-nc-1-0-en:
+  - "free-restricted"
+  LicenseRef-scancode-dmalloc:
+  - "permissive"
+  LicenseRef-scancode-do-no-harm-0.1:
+  - "proprietary-free"
+  LicenseRef-scancode-docbook:
+  - "permissive"
+  LicenseRef-scancode-dos32a-extender:
+  - "permissive"
+  LicenseRef-scancode-doug-lea:
+  - "public-domain"
+  LicenseRef-scancode-douglas-young:
+  - "permissive"
+  LicenseRef-scancode-dpl-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-dr-john-maddock:
+  - "permissive"
+  LicenseRef-scancode-dropbear:
+  - "permissive"
+  LicenseRef-scancode-dropbear-2016:
+  - "permissive"
+  LicenseRef-scancode-dtree:
+  - "permissive"
+  LicenseRef-scancode-dual-bsd-gpl:
+  - "permissive"
+  LicenseRef-scancode-dual-commercial-gpl:
+  - "copyleft"
+  LicenseRef-scancode-duende-sla-2022:
+  - "proprietary-free"
+  LicenseRef-scancode-dwtfnmfpl-3.0:
+  - "permissive"
+  LicenseRef-scancode-dynamic-drive-tou:
+  - "permissive"
+  LicenseRef-scancode-dynarch-developer:
+  - "commercial"
+  LicenseRef-scancode-dynarch-linkware:
+  - "free-restricted"
+  LicenseRef-scancode-ecfonts-1.0:
+  - "permissive"
+  LicenseRef-scancode-eclipse-sua-2001:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2002:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2003:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2004:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2005:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2010:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2011:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2014:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2014-11:
+  - "copyleft-limited"
+  LicenseRef-scancode-eclipse-sua-2017:
+  - "copyleft-limited"
+  LicenseRef-scancode-ecma-documentation:
+  - "free-restricted"
+  LicenseRef-scancode-ecma-patent-coc-0:
+  - "proprietary-free"
+  LicenseRef-scancode-ecma-patent-coc-1:
+  - "proprietary-free"
+  LicenseRef-scancode-ecma-patent-coc-2:
+  - "proprietary-free"
+  LicenseRef-scancode-ecosrh-1.0:
+  - "copyleft"
+  LicenseRef-scancode-efsl-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-egenix-1.0.0:
+  - "permissive"
+  LicenseRef-scancode-egrappler:
+  - "commercial"
+  LicenseRef-scancode-ej-technologies-eula:
+  - "commercial"
+  LicenseRef-scancode-ekioh:
+  - "permissive"
+  LicenseRef-scancode-elastic-license-2018:
+  - "source-available"
+  LicenseRef-scancode-elib-gpl:
+  - "copyleft"
+  LicenseRef-scancode-ellis-lab:
+  - "permissive"
+  LicenseRef-scancode-emit:
+  - "permissive"
+  LicenseRef-scancode-emx-library:
+  - "permissive"
+  LicenseRef-scancode-energyplus-bsd:
+  - "permissive"
+  LicenseRef-scancode-enhydra-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-epaperpress:
+  - "permissive"
+  LicenseRef-scancode-epo-osl-2005.1:
+  - "copyleft"
+  LicenseRef-scancode-eric-glass:
+  - "permissive"
+  LicenseRef-scancode-esri:
+  - "commercial"
+  LicenseRef-scancode-esri-devkit:
+  - "proprietary-free"
+  LicenseRef-scancode-etalab-2.0-en:
+  - "permissive"
+  LicenseRef-scancode-etalab-2.0-fr:
+  - "unstated-license"
+  LicenseRef-scancode-examdiff:
+  - "proprietary-free"
+  LicenseRef-scancode-excelsior-jet-runtime:
+  - "commercial"
+  LicenseRef-scancode-fabien-tassin:
+  - "permissive"
+  LicenseRef-scancode-fabric-agreement-2017:
+  - "commercial"
+  LicenseRef-scancode-facebook-nuclide:
+  - "proprietary-free"
+  LicenseRef-scancode-facebook-patent-rights-2:
+  - "patent-license"
+  LicenseRef-scancode-facebook-software-license:
+  - "proprietary-free"
+  LicenseRef-scancode-fair-source-0.9:
+  - "source-available"
+  LicenseRef-scancode-fancyzoom:
+  - "proprietary-free"
+  LicenseRef-scancode-fastbuild-2012-2020:
+  - "permissive"
+  LicenseRef-scancode-fatfs:
+  - "permissive"
+  LicenseRef-scancode-fftpack-2004:
+  - "permissive"
+  LicenseRef-scancode-filament-group-mit:
+  - "permissive"
+  LicenseRef-scancode-first-works-appreciative-1.2:
+  - "proprietary-free"
+  LicenseRef-scancode-flex-2.5:
+  - "permissive"
+  LicenseRef-scancode-flex2sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-flora-1.1:
+  - "permissive"
+  LicenseRef-scancode-flowplayer-gpl-3.0:
+  - "copyleft"
+  LicenseRef-scancode-font-alias:
+  - "permissive"
+  LicenseRef-scancode-foobar2000:
+  - "proprietary-free"
+  LicenseRef-scancode-fpl:
+  - "permissive"
+  LicenseRef-scancode-fplot:
+  - "permissive"
+  LicenseRef-scancode-fraunhofer-iso-14496-10:
+  - "permissive"
+  LicenseRef-scancode-free-art-1.3:
+  - "permissive"
+  LicenseRef-scancode-free-fork:
+  - "copyleft-limited"
+  LicenseRef-scancode-free-unknown:
+  - "unknown"
+  LicenseRef-scancode-freebsd-boot:
+  - "permissive"
+  LicenseRef-scancode-freebsd-first:
+  - "permissive"
+  LicenseRef-scancode-freemarker:
+  - "permissive"
+  LicenseRef-scancode-freetts:
+  - "permissive"
+  LicenseRef-scancode-freetype-patent:
+  - "patent-license"
+  LicenseRef-scancode-froala-owdl-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-frontier-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-fsf-notice:
+  - "permissive"
+  LicenseRef-scancode-fsf-unlimited-no-warranty:
+  - "permissive"
+  LicenseRef-scancode-ftdi:
+  - "proprietary-free"
+  LicenseRef-scancode-ftpbean:
+  - "proprietary-free"
+  LicenseRef-scancode-gareth-mccaughan:
+  - "permissive"
+  LicenseRef-scancode-gary-s-brown:
+  - "permissive"
+  LicenseRef-scancode-gcel-2022:
+  - "free-restricted"
+  LicenseRef-scancode-gco-v3.0:
+  - "proprietary-free"
+  LicenseRef-scancode-gdcl:
+  - "permissive"
+  LicenseRef-scancode-generic-cla:
+  - "generic"
+  LicenseRef-scancode-generic-export-compliance:
+  - "generic"
+  LicenseRef-scancode-generic-tos:
+  - "generic"
+  LicenseRef-scancode-generic-trademark:
+  - "generic"
+  LicenseRef-scancode-genivia-gsoap:
+  - "commercial"
+  LicenseRef-scancode-geoff-kuenning-1993:
+  - "permissive"
+  LicenseRef-scancode-ghostpdl-permissive:
+  - "permissive"
+  LicenseRef-scancode-ghostscript-1988:
+  - "copyleft"
+  LicenseRef-scancode-gitlab-ee:
+  - "commercial"
+  LicenseRef-scancode-gladman-older-rijndael-code:
+  - "permissive"
+  LicenseRef-scancode-glut:
+  - "permissive"
+  LicenseRef-scancode-gnu-emacs-gpl-1988:
+  - "copyleft"
+  LicenseRef-scancode-goahead:
+  - "proprietary-free"
+  LicenseRef-scancode-good-boy:
+  - "permissive"
+  LicenseRef-scancode-google-analytics-tos:
+  - "proprietary-free"
+  LicenseRef-scancode-google-analytics-tos-2015:
+  - "proprietary-free"
+  LicenseRef-scancode-google-analytics-tos-2016:
+  - "proprietary-free"
+  LicenseRef-scancode-google-analytics-tos-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-google-apis-tos-2021:
+  - "proprietary-free"
+  LicenseRef-scancode-google-cla:
+  - "patent-license"
+  LicenseRef-scancode-google-corporate-cla:
+  - "patent-license"
+  LicenseRef-scancode-google-maps-tos-2018-02-07:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-05-01:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-06-07:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-07-09:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-07-19:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-10-01:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2018-10-31:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2019-05-02:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2019-11-21:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2020-04-02:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2020-04-27:
+  - "proprietary-free"
+  LicenseRef-scancode-google-maps-tos-2020-05-06:
+  - "proprietary-free"
+  LicenseRef-scancode-google-ml-kit-tos-2022:
+  - "proprietary-free"
+  LicenseRef-scancode-google-patent-license:
+  - "patent-license"
+  LicenseRef-scancode-google-patent-license-fuchsia:
+  - "patent-license"
+  LicenseRef-scancode-google-patent-license-fuschia:
+  - "patent-license"
+  LicenseRef-scancode-google-patent-license-golang:
+  - "patent-license"
+  LicenseRef-scancode-google-patent-license-webm:
+  - "patent-license"
+  LicenseRef-scancode-google-patent-license-webrtc:
+  - "patent-license"
+  LicenseRef-scancode-google-playcore-sdk-tos-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-google-tos-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-google-tos-2014:
+  - "proprietary-free"
+  LicenseRef-scancode-google-tos-2017:
+  - "proprietary-free"
+  LicenseRef-scancode-google-tos-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-google-tos-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-gpl-2.0-adaptec:
+  - "copyleft"
+  LicenseRef-scancode-gpl-2.0-djvu:
+  - "copyleft"
+  LicenseRef-scancode-gpl-2.0-koterov:
+  - "copyleft"
+  LicenseRef-scancode-graphics-gems:
+  - "permissive"
+  LicenseRef-scancode-greg-roelofs:
+  - "permissive"
+  LicenseRef-scancode-gregory-pietsch:
+  - "permissive"
+  LicenseRef-scancode-gsoap-1.3a:
+  - "copyleft-limited"
+  LicenseRef-scancode-gust-font-1.0:
+  - "copyleft"
+  LicenseRef-scancode-gust-font-2006-09-30:
+  - "copyleft"
+  LicenseRef-scancode-gutenberg-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-h2-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-hacos-1.2:
+  - "copyleft"
+  LicenseRef-scancode-happy-bunny:
+  - "permissive"
+  LicenseRef-scancode-hauppauge-firmware-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-hauppauge-firmware-oem:
+  - "proprietary-free"
+  LicenseRef-scancode-hazelcast-community-1.0:
+  - "source-available"
+  LicenseRef-scancode-hdf4:
+  - "permissive"
+  LicenseRef-scancode-hdf5:
+  - "permissive"
+  LicenseRef-scancode-hdparm:
+  - "permissive"
+  LicenseRef-scancode-helios-eula:
+  - "commercial"
+  LicenseRef-scancode-helix:
+  - "proprietary-free"
+  LicenseRef-scancode-here-disclaimer:
+  - "unstated-license"
+  LicenseRef-scancode-here-proprietary:
+  - "commercial"
+  LicenseRef-scancode-hessla:
+  - "proprietary-free"
+  LicenseRef-scancode-hidapi:
+  - "permissive"
+  LicenseRef-scancode-hippocratic-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-hippocratic-1.1:
+  - "free-restricted"
+  LicenseRef-scancode-hippocratic-1.2:
+  - "free-restricted"
+  LicenseRef-scancode-hippocratic-2.0:
+  - "free-restricted"
+  LicenseRef-scancode-historical-ntp:
+  - "permissive"
+  LicenseRef-scancode-historical-sell-variant:
+  - "permissive"
+  LicenseRef-scancode-homebrewed:
+  - "permissive"
+  LicenseRef-scancode-hot-potato:
+  - "permissive"
+  LicenseRef-scancode-hp:
+  - "proprietary-free"
+  LicenseRef-scancode-hp-enterprise-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-hp-netperf:
+  - "free-restricted"
+  LicenseRef-scancode-hp-proliant-essentials:
+  - "commercial"
+  LicenseRef-scancode-hp-snmp-pp:
+  - "permissive"
+  LicenseRef-scancode-hp-software-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-hp-ux-java:
+  - "proprietary-free"
+  LicenseRef-scancode-hp-ux-jre:
+  - "proprietary-free"
+  LicenseRef-scancode-hs-regexp-orig:
+  - "permissive"
+  LicenseRef-scancode-html5:
+  - "permissive"
+  LicenseRef-scancode-httpget:
+  - "permissive"
+  LicenseRef-scancode-hugo:
+  - "source-available"
+  LicenseRef-scancode-hxd:
+  - "proprietary-free"
+  LicenseRef-scancode-ian-kaplan:
+  - "permissive"
+  LicenseRef-scancode-ian-piumarta:
+  - "permissive"
+  LicenseRef-scancode-ibm-as-is:
+  - "permissive"
+  LicenseRef-scancode-ibm-data-server-2011:
+  - "commercial"
+  LicenseRef-scancode-ibm-developerworks-community:
+  - "proprietary-free"
+  LicenseRef-scancode-ibm-dhcp:
+  - "permissive"
+  LicenseRef-scancode-ibm-icu:
+  - "permissive"
+  LicenseRef-scancode-ibm-java-portlet-spec-2.0:
+  - "permissive"
+  LicenseRef-scancode-ibm-jre:
+  - "commercial"
+  LicenseRef-scancode-ibm-nwsc:
+  - "permissive"
+  LicenseRef-scancode-ibm-sample:
+  - "permissive"
+  LicenseRef-scancode-ibpp:
+  - "permissive"
+  LicenseRef-scancode-ic-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-ic-shared-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-icann-public:
+  - "public-domain"
+  LicenseRef-scancode-icot-free:
+  - "permissive"
+  LicenseRef-scancode-idt-notice:
+  - "permissive"
+  LicenseRef-scancode-ietf:
+  - "permissive"
+  LicenseRef-scancode-ietf-trust:
+  - "permissive"
+  LicenseRef-scancode-ilmid:
+  - "permissive"
+  LicenseRef-scancode-imagen:
+  - "free-restricted"
+  LicenseRef-scancode-indiana-extreme:
+  - "permissive"
+  LicenseRef-scancode-infineon-free:
+  - "permissive"
+  LicenseRef-scancode-info-zip-1997-10:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2001-01:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2002-02:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2003-05:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2004-05:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2005-02:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2007-03:
+  - "permissive"
+  LicenseRef-scancode-info-zip-2009-01:
+  - "permissive"
+  LicenseRef-scancode-infonode-1.1:
+  - "commercial"
+  LicenseRef-scancode-initial-developer-public:
+  - "copyleft"
+  LicenseRef-scancode-inner-net-2.0:
+  - "permissive"
+  LicenseRef-scancode-inno-setup:
+  - "permissive"
+  LicenseRef-scancode-installsite:
+  - "free-restricted"
+  LicenseRef-scancode-intel:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-bcl:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-bsd:
+  - "permissive"
+  LicenseRef-scancode-intel-bsd-2-clause:
+  - "permissive"
+  LicenseRef-scancode-intel-code-samples:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-confidential:
+  - "commercial"
+  LicenseRef-scancode-intel-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-master-eula-sw-dev-2016:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-material:
+  - "commercial"
+  LicenseRef-scancode-intel-mcu-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-microcode:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-osl-1989:
+  - "permissive"
+  LicenseRef-scancode-intel-osl-1993:
+  - "permissive"
+  LicenseRef-scancode-intel-royalty-free:
+  - "permissive"
+  LicenseRef-scancode-intel-sample-source-code-2015:
+  - "proprietary-free"
+  LicenseRef-scancode-intel-scl:
+  - "proprietary-free"
+  LicenseRef-scancode-iozone:
+  - "proprietary-free"
+  LicenseRef-scancode-iptc-2006:
+  - "proprietary-free"
+  LicenseRef-scancode-irfanview-eula:
+  - "commercial"
+  LicenseRef-scancode-iso-14496-10:
+  - "permissive"
+  LicenseRef-scancode-iso-8879:
+  - "permissive"
+  LicenseRef-scancode-iso-recorder:
+  - "proprietary-free"
+  LicenseRef-scancode-isotope-cla:
+  - "commercial"
+  LicenseRef-scancode-issl-2018:
+  - "free-restricted"
+  LicenseRef-scancode-itc-eula:
+  - "commercial"
+  LicenseRef-scancode-itu:
+  - "permissive"
+  LicenseRef-scancode-itu-t:
+  - "free-restricted"
+  LicenseRef-scancode-itu-t-gpl:
+  - "copyleft"
+  LicenseRef-scancode-itunes:
+  - "proprietary-free"
+  LicenseRef-scancode-ja-sig:
+  - "permissive"
+  LicenseRef-scancode-jahia-1.3.1:
+  - "copyleft"
+  LicenseRef-scancode-jam-stapl:
+  - "free-restricted"
+  LicenseRef-scancode-jamon:
+  - "free-restricted"
+  LicenseRef-scancode-jason-mayes:
+  - "permissive"
+  LicenseRef-scancode-jasper-1.0:
+  - "permissive"
+  LicenseRef-scancode-java-app-stub:
+  - "permissive"
+  LicenseRef-scancode-java-research-1.5:
+  - "proprietary-free"
+  LicenseRef-scancode-java-research-1.6:
+  - "proprietary-free"
+  LicenseRef-scancode-jboss-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-jdbm-1.00:
+  - "permissive"
+  LicenseRef-scancode-jdom:
+  - "permissive"
+  LicenseRef-scancode-jelurida-public-1.1:
+  - "copyleft"
+  LicenseRef-scancode-jetbrains-purchase-terms:
+  - "commercial"
+  LicenseRef-scancode-jetbrains-toolbox-oss-3:
+  - "proprietary-free"
+  LicenseRef-scancode-jetty:
+  - "permissive"
+  LicenseRef-scancode-jetty-ccla-1.1:
+  - "proprietary-free"
+  LicenseRef-scancode-jgraph:
+  - "permissive"
+  LicenseRef-scancode-jgraph-general:
+  - "proprietary-free"
+  LicenseRef-scancode-jide-sla:
+  - "commercial"
+  LicenseRef-scancode-jj2000:
+  - "free-restricted"
+  LicenseRef-scancode-jmagnetic:
+  - "proprietary-free"
+  LicenseRef-scancode-josl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-jpnic-mdnkit:
+  - "permissive"
+  LicenseRef-scancode-jprs-oscl-1.1:
+  - "free-restricted"
+  LicenseRef-scancode-jpython-1.1:
+  - "permissive"
+  LicenseRef-scancode-jquery-pd:
+  - "public-domain"
+  LicenseRef-scancode-jrunner:
+  - "proprietary-free"
+  LicenseRef-scancode-jscheme:
+  - "permissive"
+  LicenseRef-scancode-jsfromhell:
+  - "permissive"
+  LicenseRef-scancode-json-js-pd:
+  - "public-domain"
+  LicenseRef-scancode-json-pd:
+  - "public-domain"
+  LicenseRef-scancode-jsr-107-jcache-spec:
+  - "proprietary-free"
+  LicenseRef-scancode-jsr-107-jcache-spec-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-jython:
+  - "permissive"
+  LicenseRef-scancode-kalle-kaukonen:
+  - "permissive"
+  LicenseRef-scancode-karl-peterson:
+  - "free-restricted"
+  LicenseRef-scancode-katharos-0.1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-kde-accepted-gpl:
+  - "copyleft"
+  LicenseRef-scancode-kde-accepted-lgpl:
+  - "copyleft"
+  LicenseRef-scancode-keith-rule:
+  - "permissive"
+  LicenseRef-scancode-kerberos:
+  - "permissive"
+  LicenseRef-scancode-kevan-stannard:
+  - "permissive"
+  LicenseRef-scancode-kevlin-henney:
+  - "permissive"
+  LicenseRef-scancode-khronos:
+  - "permissive"
+  LicenseRef-scancode-kreative-relay-fonts-free-1.2f:
+  - "proprietary-free"
+  LicenseRef-scancode-kumar-robotics:
+  - "permissive"
+  LicenseRef-scancode-larabie:
+  - "proprietary-free"
+  LicenseRef-scancode-lavantech:
+  - "commercial"
+  LicenseRef-scancode-lcs-telegraphics:
+  - "permissive"
+  LicenseRef-scancode-ldap-sdk-free-use:
+  - "permissive"
+  LicenseRef-scancode-ldpc-1994:
+  - "copyleft"
+  LicenseRef-scancode-ldpc-1997:
+  - "copyleft"
+  LicenseRef-scancode-ldpc-1999:
+  - "copyleft"
+  LicenseRef-scancode-ldpgpl-1:
+  - "copyleft"
+  LicenseRef-scancode-ldpgpl-1a:
+  - "copyleft"
+  LicenseRef-scancode-ldpl-2.0:
+  - "copyleft"
+  LicenseRef-scancode-ldpm-1998:
+  - "copyleft"
+  LicenseRef-scancode-leap-motion-sdk-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-lha:
+  - "free-restricted"
+  LicenseRef-scancode-libcap:
+  - "permissive"
+  LicenseRef-scancode-libgeotiff:
+  - "permissive"
+  LicenseRef-scancode-libmib:
+  - "permissive"
+  LicenseRef-scancode-libmng-2007:
+  - "permissive"
+  LicenseRef-scancode-libpbm:
+  - "permissive"
+  LicenseRef-scancode-librato-exception:
+  - "proprietary-free"
+  LicenseRef-scancode-libselinux-pd:
+  - "public-domain"
+  LicenseRef-scancode-libsrv-1.0.2:
+  - "permissive"
+  LicenseRef-scancode-libzip:
+  - "permissive"
+  LicenseRef-scancode-license-file-reference:
+  - "unknown"
+  LicenseRef-scancode-lil-1:
+  - "permissive"
+  LicenseRef-scancode-lilo:
+  - "permissive"
+  LicenseRef-scancode-linotype-eula:
+  - "commercial"
+  LicenseRef-scancode-linum:
+  - "permissive"
+  LicenseRef-scancode-linux-device-drivers:
+  - "permissive"
+  LicenseRef-scancode-linuxbios:
+  - "permissive"
+  LicenseRef-scancode-linuxhowtos:
+  - "permissive"
+  LicenseRef-scancode-llgpl:
+  - "copyleft-limited"
+  LicenseRef-scancode-llnl:
+  - "permissive"
+  LicenseRef-scancode-logica-1.0:
+  - "permissive"
+  LicenseRef-scancode-lontium-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-losla:
+  - "copyleft-limited"
+  LicenseRef-scancode-lsi-proprietary-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-lucre:
+  - "permissive"
+  LicenseRef-scancode-lumisoft-mail-server:
+  - "proprietary-free"
+  LicenseRef-scancode-luxi:
+  - "proprietary-free"
+  LicenseRef-scancode-lyubinskiy-dropdown:
+  - "proprietary-free"
+  LicenseRef-scancode-lyubinskiy-popup-window:
+  - "proprietary-free"
+  LicenseRef-scancode-lzma-sdk-2006:
+  - "copyleft-limited"
+  LicenseRef-scancode-lzma-sdk-2008:
+  - "copyleft-limited"
+  LicenseRef-scancode-lzma-sdk-original:
+  - "copyleft-limited"
+  LicenseRef-scancode-lzma-sdk-pd:
+  - "public-domain"
+  LicenseRef-scancode-madwifi-dual:
+  - "permissive"
+  LicenseRef-scancode-mame:
+  - "free-restricted"
+  LicenseRef-scancode-manfred-klein-fonts-tos:
+  - "free-restricted"
+  LicenseRef-scancode-mapbox-tos-2021:
+  - "commercial"
+  LicenseRef-scancode-markus-kuhn-license:
+  - "permissive"
+  LicenseRef-scancode-martin-birgmeier:
+  - "permissive"
+  LicenseRef-scancode-marvell-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-marvell-firmware-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-matt-gallagher-attribution:
+  - "permissive"
+  LicenseRef-scancode-matthew-kwan:
+  - "permissive"
+  LicenseRef-scancode-matthew-welch-font-license:
+  - "free-restricted"
+  LicenseRef-scancode-mattkruse:
+  - "permissive"
+  LicenseRef-scancode-maxmind-geolite2-eula-2019:
+  - "copyleft"
+  LicenseRef-scancode-maxmind-odl:
+  - "free-restricted"
+  LicenseRef-scancode-mcafee-tou:
+  - "proprietary-free"
+  LicenseRef-scancode-mcrae-pl-4-r53:
+  - "proprietary-free"
+  LicenseRef-scancode-mediainfo-lib:
+  - "permissive"
+  LicenseRef-scancode-melange:
+  - "proprietary-free"
+  LicenseRef-scancode-mentalis:
+  - "permissive"
+  LicenseRef-scancode-merit-network-derivative:
+  - "copyleft"
+  LicenseRef-scancode-metageek-inssider-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-metrolink-1.0:
+  - "copyleft"
+  LicenseRef-scancode-mgopen-font-license:
+  - "permissive"
+  LicenseRef-scancode-michael-barr:
+  - "permissive"
+  LicenseRef-scancode-michigan-disclaimer:
+  - "permissive"
+  LicenseRef-scancode-microchip-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-microsoft-windows-rally-devkit:
+  - "proprietary-free"
+  LicenseRef-scancode-mike95:
+  - "free-restricted"
+  LicenseRef-scancode-minecraft-mod:
+  - "proprietary-free"
+  LicenseRef-scancode-minpack:
+  - "permissive"
+  LicenseRef-scancode-mit-1995:
+  - "permissive"
+  LicenseRef-scancode-mit-addition:
+  - "permissive"
+  LicenseRef-scancode-mit-license-1998:
+  - "permissive"
+  LicenseRef-scancode-mit-modification-obligations:
+  - "permissive"
+  LicenseRef-scancode-mit-nagy:
+  - "permissive"
+  LicenseRef-scancode-mit-no-advert-export-control:
+  - "permissive"
+  LicenseRef-scancode-mit-no-trademarks:
+  - "permissive"
+  LicenseRef-scancode-mit-old-style:
+  - "permissive"
+  LicenseRef-scancode-mit-old-style-sparse:
+  - "permissive"
+  LicenseRef-scancode-mit-readme:
+  - "permissive"
+  LicenseRef-scancode-mit-specification-disclaimer:
+  - "permissive"
+  LicenseRef-scancode-mit-synopsys:
+  - "permissive"
+  LicenseRef-scancode-mit-taylor-variant:
+  - "permissive"
+  LicenseRef-scancode-mit-veillard-variant:
+  - "permissive"
+  LicenseRef-scancode-mit-xfig:
+  - "permissive"
+  LicenseRef-scancode-mod-dav-1.0:
+  - "permissive"
+  LicenseRef-scancode-monetdb-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-motorola:
+  - "permissive"
+  LicenseRef-scancode-moxa-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-mozilla-gc:
+  - "permissive"
+  LicenseRef-scancode-mozilla-ospl-1.0:
+  - "patent-license"
+  LicenseRef-scancode-mpeg-7:
+  - "proprietary-free"
+  LicenseRef-scancode-mpeg-iso:
+  - "permissive"
+  LicenseRef-scancode-mpeg-ssg:
+  - "permissive"
+  LicenseRef-scancode-ms-asp-net-ajax-supp-terms:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-mvc3:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-mvc4:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-mvc4-extensions:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-software:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-tools-pre-release:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-web-optimization:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-web-pages-2:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-asp-net-web-pages-templates:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-azure-data-studio:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-azure-spatialanchors-2.9.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-capicom:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-cl:
+  - "copyleft-limited"
+  LicenseRef-scancode-ms-cla:
+  - "patent-license"
+  LicenseRef-scancode-ms-control-spy-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-data-tier-af-2022:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-dev-services-2018-06:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-dev-services-agreement:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-device-emulator-3.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-direct3d-d3d120n7-1.1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-directx-sdk-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-dxsdk-d3dx-9.29.952.3:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-enterprise-library-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-entity-framework-4.1:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-entity-framework-5:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-eula-win-script-host:
+  - "commercial"
+  LicenseRef-scancode-ms-exchange-srv-2010-sp2-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-iis-container-eula-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-ilmerge:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-invisible-eula-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-jdbc-driver-40-sql-server:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-jdbc-driver-41-sql-server:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-jdbc-driver-60-sql-server:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-kinext-win-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-limited-community:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-limited-public:
+  - "permissive"
+  LicenseRef-scancode-ms-lpl:
+  - "permissive"
+  LicenseRef-scancode-ms-msn-webgrease:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-framework-4-supp-terms:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-framework-deployment:
+  - "commercial"
+  LicenseRef-scancode-ms-net-library:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-library-2016-05:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-library-2018-11:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-library-2019-06:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-net-library-2020-09:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-nt-resource-kit:
+  - "commercial"
+  LicenseRef-scancode-ms-nuget:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-nuget-package-manager:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-office-extensible-file:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-office-system-programs-eula:
+  - "commercial"
+  LicenseRef-scancode-ms-patent-promise:
+  - "patent-license"
+  LicenseRef-scancode-ms-patent-promise-mono:
+  - "patent-license"
+  LicenseRef-scancode-ms-permissive-1.1:
+  - "permissive"
+  LicenseRef-scancode-ms-platform-sdk:
+  - "commercial"
+  LicenseRef-scancode-ms-programsynthesis-7.22.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-python-vscode-pylance-2021:
+  - "commercial"
+  LicenseRef-scancode-ms-reactive-extensions-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-refl:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-remote-ndis-usb-kit:
+  - "commercial"
+  LicenseRef-scancode-ms-research-shared-source:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-rsl:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-silverlight-3:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-sql-server-compact-4.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-sql-server-data-tools:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-sspl:
+  - "permissive"
+  LicenseRef-scancode-ms-sysinternals-sla:
+  - "commercial"
+  LicenseRef-scancode-ms-testplatform-17.0.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-ttf-eula:
+  - "commercial"
+  LicenseRef-scancode-ms-typescript-msbuild-4.1.4:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-2008-runtime:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-2010-runtime:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-2015-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-cpp-2015-runtime:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-studio-2017:
+  - "commercial"
+  LicenseRef-scancode-ms-visual-studio-2017-tools:
+  - "commercial"
+  LicenseRef-scancode-ms-visual-studio-code:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-studio-code-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-visual-studio-code-2022:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-vs-addons-ext-17.2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-web-developer-tools-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-win-container-eula-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-win-sdk-server-2008-net-3.5:
+  - "commercial"
+  LicenseRef-scancode-ms-windows-driver-kit:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-windows-identity-foundation:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-windows-os-2018:
+  - "commercial"
+  LicenseRef-scancode-ms-windows-sdk-win10:
+  - "commercial"
+  LicenseRef-scancode-ms-windows-sdk-win7-net-4:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-windows-server-2003-ddk:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-windows-server-2003-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-ws-routing-spec:
+  - "permissive"
+  LicenseRef-scancode-ms-xamarin-uitest3.2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ms-xml-core-4.0:
+  - "proprietary-free"
+  LicenseRef-scancode-msj-sample-code:
+  - "permissive"
+  LicenseRef-scancode-msntp:
+  - "copyleft"
+  LicenseRef-scancode-msppl:
+  - "proprietary-free"
+  LicenseRef-scancode-mtx-licensing-statement:
+  - "proprietary-free"
+  LicenseRef-scancode-mulanpsl-1.0-en:
+  - "permissive"
+  LicenseRef-scancode-mulanpsl-2.0-en:
+  - "permissive"
+  LicenseRef-scancode-mule-source-1.1.3:
+  - "copyleft-limited"
+  LicenseRef-scancode-mule-source-1.1.4:
+  - "copyleft-limited"
+  LicenseRef-scancode-mulle-kybernetik:
+  - "permissive"
+  LicenseRef-scancode-mvt-1.1:
+  - "free-restricted"
+  LicenseRef-scancode-mx4j:
+  - "permissive"
+  LicenseRef-scancode-naughter:
+  - "free-restricted"
+  LicenseRef-scancode-ncbi:
+  - "public-domain"
+  LicenseRef-scancode-nero-eula:
+  - "commercial"
+  LicenseRef-scancode-netapp-sdk-aug2020:
+  - "proprietary-free"
+  LicenseRef-scancode-netcat:
+  - "permissive"
+  LicenseRef-scancode-netcomponents:
+  - "permissive"
+  LicenseRef-scancode-netron:
+  - "permissive"
+  LicenseRef-scancode-netronome-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-network-time-protocol:
+  - "permissive"
+  LicenseRef-scancode-new-relic:
+  - "proprietary-free"
+  LicenseRef-scancode-newlib-historical:
+  - "permissive"
+  LicenseRef-scancode-newran:
+  - "permissive"
+  LicenseRef-scancode-newton-king-cla:
+  - "unstated-license"
+  LicenseRef-scancode-nexb-eula-saas-1.1.0:
+  - "commercial"
+  LicenseRef-scancode-nexb-ssla-1.1.0:
+  - "commercial"
+  LicenseRef-scancode-nice:
+  - "permissive"
+  LicenseRef-scancode-nicta-psl:
+  - "permissive"
+  LicenseRef-scancode-niels-ferguson:
+  - "permissive"
+  LicenseRef-scancode-nilsson-historical:
+  - "permissive"
+  LicenseRef-scancode-nist-srd:
+  - "permissive"
+  LicenseRef-scancode-no-license:
+  - "unstated-license"
+  LicenseRef-scancode-node-js:
+  - "permissive"
+  LicenseRef-scancode-non-violent-4.0:
+  - "proprietary-free"
+  LicenseRef-scancode-nonexclusive:
+  - "permissive"
+  LicenseRef-scancode-nortel-dasa:
+  - "permissive"
+  LicenseRef-scancode-northwoods-sla-2021:
+  - "commercial"
+  LicenseRef-scancode-notre-dame:
+  - "permissive"
+  LicenseRef-scancode-nrl-permission:
+  - "permissive"
+  LicenseRef-scancode-ntlm:
+  - "permissive"
+  LicenseRef-scancode-ntpl:
+  - "permissive"
+  LicenseRef-scancode-ntpl-origin:
+  - "permissive"
+  LicenseRef-scancode-numerical-recipes-notice:
+  - "commercial"
+  LicenseRef-scancode-nunit-v2:
+  - "permissive"
+  LicenseRef-scancode-nvidia:
+  - "permissive"
+  LicenseRef-scancode-nvidia-2002:
+  - "permissive"
+  LicenseRef-scancode-nvidia-apex-sdk-eula-2011:
+  - "proprietary-free"
+  LicenseRef-scancode-nvidia-cuda-supplement-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-nvidia-gov:
+  - "permissive"
+  LicenseRef-scancode-nvidia-isaac-eula-2019.1:
+  - "proprietary-free"
+  LicenseRef-scancode-nvidia-ngx-eula-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-nvidia-sdk-eula-v0.11:
+  - "proprietary-free"
+  LicenseRef-scancode-nvidia-video-codec-agreement:
+  - "proprietary-free"
+  LicenseRef-scancode-nwhm:
+  - "permissive"
+  LicenseRef-scancode-nxp-firmware-patent:
+  - "proprietary-free"
+  LicenseRef-scancode-nxp-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-nxp-mc-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-nxp-microctl-proprietary:
+  - "proprietary-free"
+  LicenseRef-scancode-nxp-warranty-disclaimer:
+  - "proprietary-free"
+  LicenseRef-scancode-nysl-0.9982:
+  - "permissive"
+  LicenseRef-scancode-nysl-0.9982-jp:
+  - "permissive"
+  LicenseRef-scancode-o-young-jong:
+  - "permissive"
+  LicenseRef-scancode-oasis-ipr-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-oasis-ipr-policy-2014:
+  - "proprietary-free"
+  LicenseRef-scancode-oasis-ws-security-spec:
+  - "permissive"
+  LicenseRef-scancode-ocb-non-military-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-ocb-open-source-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-ocb-patent-openssl-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-oclc-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-ocsl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-oculus-sdk:
+  - "copyleft-limited"
+  LicenseRef-scancode-oculus-sdk-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-oculus-sdk-3.5:
+  - "proprietary-free"
+  LicenseRef-scancode-odc-1.0:
+  - "copyleft"
+  LicenseRef-scancode-odl:
+  - "permissive"
+  LicenseRef-scancode-odmg:
+  - "permissive"
+  LicenseRef-scancode-ogc:
+  - "permissive"
+  LicenseRef-scancode-ogc-2006:
+  - "permissive"
+  LicenseRef-scancode-ogc-document-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-ogl-1.0a:
+  - "permissive"
+  LicenseRef-scancode-ogl-canada-2.0-fr:
+  - "permissive"
+  LicenseRef-scancode-ogl-wpd-3.0:
+  - "permissive"
+  LicenseRef-scancode-ohdl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-okl:
+  - "copyleft"
+  LicenseRef-scancode-open-diameter:
+  - "copyleft"
+  LicenseRef-scancode-open-group:
+  - "copyleft-limited"
+  LicenseRef-scancode-openi-pl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-openmap:
+  - "copyleft-limited"
+  LicenseRef-scancode-openmarket-fastcgi:
+  - "permissive"
+  LicenseRef-scancode-opennetcf-shared-source:
+  - "proprietary-free"
+  LicenseRef-scancode-openorb-1.0:
+  - "permissive"
+  LicenseRef-scancode-openpbs-2.3:
+  - "copyleft-limited"
+  LicenseRef-scancode-opensaml-1.0:
+  - "permissive"
+  LicenseRef-scancode-openssl:
+  - "permissive"
+  LicenseRef-scancode-openvpn-as-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-opera-eula-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-opera-eula-eea-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-opera-widget-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-opl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-opml-1.0:
+  - "permissive"
+  LicenseRef-scancode-opnl-1.0:
+  - "permissive"
+  LicenseRef-scancode-opnl-2.0:
+  - "permissive"
+  LicenseRef-scancode-oracle-bcl-java-platform-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-bcl-java-platform-2017:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-bcl-javaee:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-bcl-javase-javafx-2012:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-bcl-javase-javafx-2013:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-bcl-jsse-1.0.3:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-code-samples-bsd:
+  - "free-restricted"
+  LicenseRef-scancode-oracle-commercial-db-11g2:
+  - "commercial"
+  LicenseRef-scancode-oracle-devtools-vsnet-dev:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-entitlement-05-15:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-java-ee-sdk-2010:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-master-agreement:
+  - "commercial"
+  LicenseRef-scancode-oracle-nftc-2021:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-otn-javase-2019:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-sql-developer:
+  - "proprietary-free"
+  LicenseRef-scancode-oracle-web-sites-tou:
+  - "proprietary-free"
+  LicenseRef-scancode-oreilly-notice:
+  - "permissive"
+  LicenseRef-scancode-osetpl-2.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-osf-1990:
+  - "permissive"
+  LicenseRef-scancode-osgi-spec-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-ossn-3.0:
+  - "proprietary-free"
+  LicenseRef-scancode-oswego-concurrent:
+  - "permissive"
+  LicenseRef-scancode-other-copyleft:
+  - "generic"
+  LicenseRef-scancode-other-permissive:
+  - "generic"
+  LicenseRef-scancode-otn-dev-dist:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-dev-dist-2009:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-dev-dist-2014:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-dev-dist-2016:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-early-adopter-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-early-adopter-development:
+  - "proprietary-free"
+  LicenseRef-scancode-otn-standard-2014-09:
+  - "proprietary-free"
+  LicenseRef-scancode-owal-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-owf-cla-1.0-copyright:
+  - "permissive"
+  LicenseRef-scancode-owf-cla-1.0-copyright-patent:
+  - "patent-license"
+  LicenseRef-scancode-owfa-1.0:
+  - "patent-license"
+  LicenseRef-scancode-owfa-1.0-patent-only:
+  - "patent-license"
+  LicenseRef-scancode-owtchart:
+  - "permissive"
+  LicenseRef-scancode-oxygen-xml-webhelp-eula:
+  - "commercial"
+  LicenseRef-scancode-ozplb-1.0:
+  - "permissive"
+  LicenseRef-scancode-ozplb-1.1:
+  - "permissive"
+  LicenseRef-scancode-paint-net:
+  - "proprietary-free"
+  LicenseRef-scancode-paolo-messina-2000:
+  - "permissive"
+  LicenseRef-scancode-paraview-1.2:
+  - "permissive"
+  LicenseRef-scancode-passive-aggressive:
+  - "proprietary-free"
+  LicenseRef-scancode-patent-disclaimer:
+  - "permissive"
+  LicenseRef-scancode-paul-hsieh-derivative:
+  - "free-restricted"
+  LicenseRef-scancode-paul-hsieh-exposition:
+  - "free-restricted"
+  LicenseRef-scancode-paul-mackerras:
+  - "permissive"
+  LicenseRef-scancode-paul-mackerras-binary:
+  - "permissive"
+  LicenseRef-scancode-paul-mackerras-new:
+  - "permissive"
+  LicenseRef-scancode-paul-mackerras-simplified:
+  - "permissive"
+  LicenseRef-scancode-paulo-soares:
+  - "permissive"
+  LicenseRef-scancode-paypal-sdk-2013-2016:
+  - "permissive"
+  LicenseRef-scancode-pbl-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-pcre:
+  - "permissive"
+  LicenseRef-scancode-pd-mit:
+  - "permissive"
+  LicenseRef-scancode-pd-programming:
+  - "permissive"
+  LicenseRef-scancode-pdf-creator-pilot:
+  - "commercial"
+  LicenseRef-scancode-pdl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-perl-1.0:
+  - "permissive"
+  LicenseRef-scancode-peter-deutsch-document:
+  - "permissive"
+  LicenseRef-scancode-pfe-proprietary-notice:
+  - "proprietary-free"
+  LicenseRef-scancode-pftijah-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-pftus-1.1:
+  - "proprietary-free"
+  LicenseRef-scancode-phil-bunce:
+  - "public-domain"
+  LicenseRef-scancode-philippe-de-muyter:
+  - "permissive"
+  LicenseRef-scancode-philips-proprietary-notice2000:
+  - "commercial"
+  LicenseRef-scancode-phorum-2.0:
+  - "permissive"
+  LicenseRef-scancode-php-2.0.2:
+  - "permissive"
+  LicenseRef-scancode-pine:
+  - "permissive"
+  LicenseRef-scancode-pivotal-tou:
+  - "commercial"
+  LicenseRef-scancode-pixabay-content:
+  - "free-restricted"
+  LicenseRef-scancode-planet-source-code:
+  - "free-restricted"
+  LicenseRef-scancode-pml-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-pngsuite:
+  - "permissive"
+  LicenseRef-scancode-politepix-pl-1.0:
+  - "permissive"
+  LicenseRef-scancode-polyform-defensive-1.0.0:
+  - "source-available"
+  LicenseRef-scancode-polyform-free-trial-1.0.0:
+  - "source-available"
+  LicenseRef-scancode-polyform-internal-use-1.0.0:
+  - "source-available"
+  LicenseRef-scancode-polyform-perimeter-1.0.0:
+  - "source-available"
+  LicenseRef-scancode-polyform-shield-1.0.0:
+  - "source-available"
+  LicenseRef-scancode-polyform-strict-1.0.0:
+  - "proprietary-free"
+  LicenseRef-scancode-powervr-tools-software-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-ppp:
+  - "permissive"
+  LicenseRef-scancode-proprietary:
+  - "generic"
+  LicenseRef-scancode-proprietary-license:
+  - "generic"
+  LicenseRef-scancode-prosperity-1.0.1:
+  - "proprietary-free"
+  LicenseRef-scancode-prosperity-2.0:
+  - "source-available"
+  LicenseRef-scancode-prosperity-3.0:
+  - "source-available"
+  LicenseRef-scancode-protobuf:
+  - "permissive"
+  LicenseRef-scancode-psf-3.7.2:
+  - "permissive"
+  LicenseRef-scancode-psytec-freesoft:
+  - "permissive"
+  LicenseRef-scancode-public-domain:
+  - "generic"
+  LicenseRef-scancode-public-domain-disclaimer:
+  - "generic"
+  LicenseRef-scancode-purdue-bsd:
+  - "permissive"
+  LicenseRef-scancode-pybench:
+  - "permissive"
+  LicenseRef-scancode-pycrypto:
+  - "permissive"
+  LicenseRef-scancode-pygres-2.2:
+  - "permissive"
+  LicenseRef-scancode-python-cwi:
+  - "permissive"
+  LicenseRef-scancode-qaplug:
+  - "proprietary-free"
+  LicenseRef-scancode-qca-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-qca-technology:
+  - "proprietary-free"
+  LicenseRef-scancode-qlogic-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-qlogic-microcode:
+  - "permissive"
+  LicenseRef-scancode-qpopper:
+  - "permissive"
+  LicenseRef-scancode-qt-commercial-1.1:
+  - "commercial"
+  LicenseRef-scancode-qti-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-qualcomm-iso:
+  - "free-restricted"
+  LicenseRef-scancode-qualcomm-turing:
+  - "permissive"
+  LicenseRef-scancode-quickfix-1.0:
+  - "permissive"
+  LicenseRef-scancode-quicktime:
+  - "proprietary-free"
+  LicenseRef-scancode-quin-street:
+  - "proprietary-free"
+  LicenseRef-scancode-quirksmode:
+  - "permissive"
+  LicenseRef-scancode-qwt-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-rackspace:
+  - "free-restricted"
+  LicenseRef-scancode-radvd:
+  - "permissive"
+  LicenseRef-scancode-ralf-corsepius:
+  - "permissive"
+  LicenseRef-scancode-ralink-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-rar-winrar-eula:
+  - "commercial"
+  LicenseRef-scancode-rcsl-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-rcsl-3.0:
+  - "proprietary-free"
+  LicenseRef-scancode-realm-platform-extension-2017:
+  - "proprietary-free"
+  LicenseRef-scancode-red-hat-attribution:
+  - "permissive"
+  LicenseRef-scancode-red-hat-bsd-simplified:
+  - "permissive"
+  LicenseRef-scancode-red-hat-logos:
+  - "proprietary-free"
+  LicenseRef-scancode-red-hat-trademarks:
+  - "proprietary-free"
+  LicenseRef-scancode-redis-source-available-1.0:
+  - "source-available"
+  LicenseRef-scancode-reportbug:
+  - "permissive"
+  LicenseRef-scancode-rh-eula:
+  - "copyleft"
+  LicenseRef-scancode-rh-eula-lgpl:
+  - "copyleft-limited"
+  LicenseRef-scancode-ricebsd:
+  - "permissive"
+  LicenseRef-scancode-richard-black:
+  - "permissive"
+  LicenseRef-scancode-riverbank-sip:
+  - "free-restricted"
+  LicenseRef-scancode-robert-hubley:
+  - "permissive"
+  LicenseRef-scancode-rogue-wave:
+  - "commercial"
+  LicenseRef-scancode-rsa-1990:
+  - "permissive"
+  LicenseRef-scancode-rsa-cryptoki:
+  - "permissive"
+  LicenseRef-scancode-rsa-demo:
+  - "permissive"
+  LicenseRef-scancode-rsa-md2:
+  - "free-restricted"
+  LicenseRef-scancode-rsa-md4:
+  - "permissive"
+  LicenseRef-scancode-rsa-proprietary:
+  - "commercial"
+  LicenseRef-scancode-rtools-util:
+  - "permissive"
+  LicenseRef-scancode-rubyencoder-commercial:
+  - "commercial"
+  LicenseRef-scancode-rubyencoder-loader:
+  - "proprietary-free"
+  LicenseRef-scancode-rute:
+  - "permissive"
+  LicenseRef-scancode-ryszard-szopa:
+  - "permissive"
+  LicenseRef-scancode-saas-mit:
+  - "permissive"
+  LicenseRef-scancode-saf:
+  - "permissive"
+  LicenseRef-scancode-safecopy-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-san-francisco-font:
+  - "proprietary-free"
+  LicenseRef-scancode-sandeep:
+  - "proprietary-free"
+  LicenseRef-scancode-sash:
+  - "permissive"
+  LicenseRef-scancode-sata:
+  - "permissive"
+  LicenseRef-scancode-sbia-b:
+  - "permissive"
+  LicenseRef-scancode-scancode-acknowledgment:
+  - "permissive"
+  LicenseRef-scancode-scanlogd-license:
+  - "permissive"
+  LicenseRef-scancode-scansoft-1.2:
+  - "permissive"
+  LicenseRef-scancode-scilab-en:
+  - "proprietary-free"
+  LicenseRef-scancode-scilab-fr:
+  - "proprietary-free"
+  LicenseRef-scancode-scintilla:
+  - "permissive"
+  LicenseRef-scancode-scola-en:
+  - "proprietary-free"
+  LicenseRef-scancode-scola-fr:
+  - "proprietary-free"
+  LicenseRef-scancode-scribbles:
+  - "permissive"
+  LicenseRef-scancode-script-asylum:
+  - "permissive"
+  LicenseRef-scancode-script-nikhilk:
+  - "proprietary-free"
+  LicenseRef-scancode-scrub:
+  - "proprietary-free"
+  LicenseRef-scancode-scsl-3.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-secret-labs-2011:
+  - "permissive"
+  LicenseRef-scancode-see-license:
+  - "unknown"
+  LicenseRef-scancode-sencha-commercial:
+  - "commercial"
+  LicenseRef-scancode-sencha-commercial-3.17:
+  - "commercial"
+  LicenseRef-scancode-sencha-commercial-3.9:
+  - "commercial"
+  LicenseRef-scancode-service-comp-arch:
+  - "permissive"
+  LicenseRef-scancode-sgi-cid-1.0:
+  - "permissive"
+  LicenseRef-scancode-sgi-glx-1.0:
+  - "permissive"
+  LicenseRef-scancode-sglib:
+  - "permissive"
+  LicenseRef-scancode-shavlik-eula:
+  - "commercial"
+  LicenseRef-scancode-shital-shah:
+  - "permissive"
+  LicenseRef-scancode-simpl-1.1:
+  - "permissive"
+  LicenseRef-scancode-slf4j-2005:
+  - "permissive"
+  LicenseRef-scancode-slf4j-2008:
+  - "permissive"
+  LicenseRef-scancode-slysoft-eula:
+  - "commercial"
+  LicenseRef-scancode-smail-gpl:
+  - "copyleft"
+  LicenseRef-scancode-smartlabs-freeware:
+  - "proprietary-free"
+  LicenseRef-scancode-snmp4j-smi:
+  - "commercial"
+  LicenseRef-scancode-snprintf:
+  - "permissive"
+  LicenseRef-scancode-softerra-ldap-browser-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-softfloat:
+  - "permissive"
+  LicenseRef-scancode-softfloat-2.0:
+  - "permissive"
+  LicenseRef-scancode-softsurfer:
+  - "permissive"
+  LicenseRef-scancode-solace-software-eula-2020:
+  - "proprietary-free"
+  LicenseRef-scancode-spark-jive:
+  - "proprietary-free"
+  LicenseRef-scancode-sparky:
+  - "permissive"
+  LicenseRef-scancode-speechworks-1.1:
+  - "permissive"
+  LicenseRef-scancode-splunk-3pp-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-splunk-mint-tos-2018:
+  - "proprietary-free"
+  LicenseRef-scancode-splunk-sla:
+  - "commercial"
+  LicenseRef-scancode-square-cla:
+  - "patent-license"
+  LicenseRef-scancode-squeak:
+  - "proprietary-free"
+  LicenseRef-scancode-srgb:
+  - "proprietary-free"
+  LicenseRef-scancode-ssleay:
+  - "permissive"
+  LicenseRef-scancode-ssleay-windows:
+  - "permissive"
+  LicenseRef-scancode-st-bsd-restricted:
+  - "free-restricted"
+  LicenseRef-scancode-st-mcd-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-stanford-mrouted:
+  - "copyleft-limited"
+  LicenseRef-scancode-stanford-pvrg:
+  - "permissive"
+  LicenseRef-scancode-statewizard:
+  - "copyleft-limited"
+  LicenseRef-scancode-stax:
+  - "copyleft-limited"
+  LicenseRef-scancode-stlport-2000:
+  - "permissive"
+  LicenseRef-scancode-stlport-4.5:
+  - "permissive"
+  LicenseRef-scancode-stmicro-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-stmicroelectronics-centrallabs:
+  - "free-restricted"
+  LicenseRef-scancode-stream-benchmark:
+  - "permissive"
+  LicenseRef-scancode-stu-nicholls:
+  - "permissive"
+  LicenseRef-scancode-sun-bcl-11-06:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-11-07:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-11-08:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-j2re-1.2.x:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-j2re-1.4.2:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-j2re-1.4.x:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-j2re-5.0:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-java-servlet-imp-2.1.1:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-javahelp:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-jimi-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-jre6:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-jsmq:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-opendmk:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-openjdk:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-sdk-1.3:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-sdk-1.4.2:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-sdk-5.0:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-sdk-6.0:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bcl-web-start:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-bsd-extra:
+  - "free-restricted"
+  LicenseRef-scancode-sun-communications-api:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-ejb-spec-2.1:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-ejb-spec-3.0:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-entitlement-03-15:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-entitlement-jaf:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-glassfish:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-iiop:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-java-transaction-api:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-java-web-services-dev-1.6:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-javamail:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-jsr-spec-04-2006:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-jta-spec-1.0.1:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-jta-spec-1.0.1b:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-no-high-risk-activities:
+  - "free-restricted"
+  LicenseRef-scancode-sun-project-x:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-prop-non-commercial:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-proprietary-jdk:
+  - "commercial"
+  LicenseRef-scancode-sun-rpc:
+  - "permissive"
+  LicenseRef-scancode-sun-sdk-spec-1.1:
+  - "proprietary-free"
+  LicenseRef-scancode-sun-sissl-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-sun-source:
+  - "permissive"
+  LicenseRef-scancode-sun-ssscfr-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-sunpro:
+  - "permissive"
+  LicenseRef-scancode-sunsoft:
+  - "permissive"
+  LicenseRef-scancode-supervisor:
+  - "permissive"
+  LicenseRef-scancode-sustainable-use-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-svndiff:
+  - "permissive"
+  LicenseRef-scancode-swig:
+  - "permissive"
+  LicenseRef-scancode-symphonysoft:
+  - "permissive"
+  LicenseRef-scancode-synopsys-attribution:
+  - "free-restricted"
+  LicenseRef-scancode-synopsys-mit:
+  - "permissive"
+  LicenseRef-scancode-synthesis-toolkit:
+  - "permissive"
+  LicenseRef-scancode-takao-abe:
+  - "permissive"
+  LicenseRef-scancode-takuya-ooura:
+  - "permissive"
+  LicenseRef-scancode-taligent-jdk:
+  - "proprietary-free"
+  LicenseRef-scancode-tanuki-community-sla-1.0:
+  - "copyleft"
+  LicenseRef-scancode-tanuki-community-sla-1.1:
+  - "copyleft"
+  LicenseRef-scancode-tanuki-community-sla-1.2:
+  - "copyleft"
+  LicenseRef-scancode-tanuki-community-sla-1.3:
+  - "copyleft"
+  LicenseRef-scancode-tanuki-development:
+  - "commercial"
+  LicenseRef-scancode-tanuki-maintenance:
+  - "commercial"
+  LicenseRef-scancode-teamdev-services:
+  - "commercial"
+  LicenseRef-scancode-tekhvc:
+  - "permissive"
+  LicenseRef-scancode-telerik-eula:
+  - "commercial"
+  LicenseRef-scancode-tenable-nessus:
+  - "proprietary-free"
+  LicenseRef-scancode-term-readkey:
+  - "permissive"
+  LicenseRef-scancode-tested-software:
+  - "permissive"
+  LicenseRef-scancode-tex-live:
+  - "permissive"
+  LicenseRef-scancode-tfl:
+  - "public-domain"
+  LicenseRef-scancode-tgppl-1.0:
+  - "copyleft"
+  LicenseRef-scancode-things-i-made-public-license:
+  - "permissive"
+  LicenseRef-scancode-thomas-bandt:
+  - "free-restricted"
+  LicenseRef-scancode-thor-pl:
+  - "copyleft-limited"
+  LicenseRef-scancode-ti-broadband-apps:
+  - "proprietary-free"
+  LicenseRef-scancode-ti-linux-firmware:
+  - "proprietary-free"
+  LicenseRef-scancode-ti-restricted:
+  - "commercial"
+  LicenseRef-scancode-tiger-crypto:
+  - "permissive"
+  LicenseRef-scancode-tigra-calendar-3.2:
+  - "permissive"
+  LicenseRef-scancode-tigra-calendar-4.0:
+  - "permissive"
+  LicenseRef-scancode-tim-janik-2003:
+  - "permissive"
+  LicenseRef-scancode-timestamp-picker:
+  - "permissive"
+  LicenseRef-scancode-tizen-sdk:
+  - "proprietary-free"
+  LicenseRef-scancode-tpl-1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-trademark-notice:
+  - "unstated-license"
+  LicenseRef-scancode-trca-odl-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-treeview-developer:
+  - "proprietary-free"
+  LicenseRef-scancode-treeview-distributor:
+  - "proprietary-free"
+  LicenseRef-scancode-triptracker:
+  - "proprietary-free"
+  LicenseRef-scancode-truecrypt-3.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-tsl-2018:
+  - "source-available"
+  LicenseRef-scancode-tsl-2020:
+  - "source-available"
+  LicenseRef-scancode-tso-license:
+  - "permissive"
+  LicenseRef-scancode-ttcl:
+  - "permissive"
+  LicenseRef-scancode-ttf2pt1:
+  - "permissive"
+  LicenseRef-scancode-ttyp0:
+  - "permissive"
+  LicenseRef-scancode-tumbolia:
+  - "permissive"
+  LicenseRef-scancode-twisted-snmp:
+  - "permissive"
+  LicenseRef-scancode-txl-10.5:
+  - "free-restricted"
+  LicenseRef-scancode-ubc:
+  - "permissive"
+  LicenseRef-scancode-ubuntu-font-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-unbuntu-font-1.0:
+  - "free-restricted"
+  LicenseRef-scancode-unicode:
+  - "permissive"
+  LicenseRef-scancode-unicode-data-software:
+  - "permissive"
+  LicenseRef-scancode-unicode-icu-58:
+  - "permissive"
+  LicenseRef-scancode-unicode-mappings:
+  - "permissive"
+  LicenseRef-scancode-unknown:
+  - "unknown"
+  LicenseRef-scancode-unknown-license-reference:
+  - "unknown"
+  LicenseRef-scancode-unknown-spdx:
+  - "unknown"
+  LicenseRef-scancode-unpbook:
+  - "permissive"
+  LicenseRef-scancode-unpublished-source:
+  - "generic"
+  LicenseRef-scancode-unrar:
+  - "source-available"
+  LicenseRef-scancode-unsplash:
+  - "free-restricted"
+  LicenseRef-scancode-uofu-rfpl:
+  - "proprietary-free"
+  LicenseRef-scancode-us-govt-public-domain:
+  - "generic"
+  LicenseRef-scancode-us-govt-unlimited-rights:
+  - "permissive"
+  LicenseRef-scancode-usrobotics-permissive:
+  - "permissive"
+  LicenseRef-scancode-utopia:
+  - "permissive"
+  LicenseRef-scancode-vbaccelerator:
+  - "free-restricted"
+  LicenseRef-scancode-vcalendar:
+  - "permissive"
+  LicenseRef-scancode-verisign:
+  - "proprietary-free"
+  LicenseRef-scancode-vhfpl-1.1:
+  - "copyleft"
+  LicenseRef-scancode-vic-metcalfe-pd:
+  - "public-domain"
+  LicenseRef-scancode-vicomsoft-software:
+  - "commercial"
+  LicenseRef-scancode-visual-idiot:
+  - "permissive"
+  LicenseRef-scancode-visual-numerics:
+  - "permissive"
+  LicenseRef-scancode-vita-nuova-liberal:
+  - "copyleft"
+  LicenseRef-scancode-vitesse-prop:
+  - "proprietary-free"
+  LicenseRef-scancode-vixie-cron:
+  - "permissive"
+  LicenseRef-scancode-vnc-viewer-ios:
+  - "commercial"
+  LicenseRef-scancode-volatility-vsl-v1.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-vpl-1.1:
+  - "copyleft-limited"
+  LicenseRef-scancode-vpl-1.2:
+  - "copyleft-limited"
+  LicenseRef-scancode-vs10x-code-map:
+  - "proprietary-free"
+  LicenseRef-scancode-vuforia-2013-07-29:
+  - "proprietary-free"
+  LicenseRef-scancode-w3c-docs-19990405:
+  - "free-restricted"
+  LicenseRef-scancode-w3c-docs-20021231:
+  - "free-restricted"
+  LicenseRef-scancode-w3c-documentation:
+  - "free-restricted"
+  LicenseRef-scancode-w3c-software-20021231:
+  - "permissive"
+  LicenseRef-scancode-w3c-test-suite:
+  - "free-restricted"
+  LicenseRef-scancode-warranty-disclaimer:
+  - "generic"
+  LicenseRef-scancode-waterfall-feed-parser:
+  - "free-restricted"
+  LicenseRef-scancode-westhawk:
+  - "permissive"
+  LicenseRef-scancode-whistle:
+  - "permissive"
+  LicenseRef-scancode-whitecat:
+  - "permissive"
+  LicenseRef-scancode-wide-license:
+  - "permissive"
+  LicenseRef-scancode-wifi-alliance:
+  - "commercial"
+  LicenseRef-scancode-william-alexander:
+  - "permissive"
+  LicenseRef-scancode-wince-50-shared-source:
+  - "proprietary-free"
+  LicenseRef-scancode-windriver-commercial:
+  - "commercial"
+  LicenseRef-scancode-wingo:
+  - "permissive"
+  LicenseRef-scancode-wink:
+  - "proprietary-free"
+  LicenseRef-scancode-winzip-eula:
+  - "commercial"
+  LicenseRef-scancode-winzip-self-extractor:
+  - "commercial"
+  LicenseRef-scancode-wol:
+  - "permissive"
+  LicenseRef-scancode-wordnet:
+  - "permissive"
+  LicenseRef-scancode-wrox:
+  - "permissive"
+  LicenseRef-scancode-wrox-download:
+  - "source-available"
+  LicenseRef-scancode-ws-addressing-spec:
+  - "permissive"
+  LicenseRef-scancode-ws-policy-specification:
+  - "permissive"
+  LicenseRef-scancode-ws-trust-specification:
+  - "permissive"
+  LicenseRef-scancode-wtfnmfpl-1.0:
+  - "permissive"
+  LicenseRef-scancode-wtfpl-1.0:
+  - "public-domain"
+  LicenseRef-scancode-wthpl-1.0:
+  - "public-domain"
+  LicenseRef-scancode-wxwidgets:
+  - "permissive"
+  LicenseRef-scancode-wxwindows-r-3.0:
+  - "copyleft-limited"
+  LicenseRef-scancode-wxwindows-u-3.0:
+  - "permissive"
+  LicenseRef-scancode-x11-acer:
+  - "permissive"
+  LicenseRef-scancode-x11-adobe:
+  - "permissive"
+  LicenseRef-scancode-x11-adobe-dec:
+  - "permissive"
+  LicenseRef-scancode-x11-bitstream:
+  - "permissive"
+  LicenseRef-scancode-x11-dec1:
+  - "permissive"
+  LicenseRef-scancode-x11-dec2:
+  - "permissive"
+  LicenseRef-scancode-x11-doc:
+  - "permissive"
+  LicenseRef-scancode-x11-dsc:
+  - "permissive"
+  LicenseRef-scancode-x11-hanson:
+  - "permissive"
+  LicenseRef-scancode-x11-ibm:
+  - "copyleft"
+  LicenseRef-scancode-x11-lucent:
+  - "permissive"
+  LicenseRef-scancode-x11-lucent-variant:
+  - "permissive"
+  LicenseRef-scancode-x11-oar:
+  - "permissive"
+  LicenseRef-scancode-x11-opengl:
+  - "permissive"
+  LicenseRef-scancode-x11-quarterdeck:
+  - "permissive"
+  LicenseRef-scancode-x11-r75:
+  - "permissive"
+  LicenseRef-scancode-x11-realmode:
+  - "permissive"
+  LicenseRef-scancode-x11-sg:
+  - "permissive"
+  LicenseRef-scancode-x11-stanford:
+  - "permissive"
+  LicenseRef-scancode-x11-tektronix:
+  - "permissive"
+  LicenseRef-scancode-x11-x11r5:
+  - "permissive"
+  LicenseRef-scancode-x11-xconsortium-veillard:
+  - "permissive"
+  LicenseRef-scancode-x11r5-authors:
+  - "permissive"
+  LicenseRef-scancode-xceed-community-2021:
+  - "proprietary-free"
+  LicenseRef-scancode-xfree86-1.0:
+  - "permissive"
+  LicenseRef-scancode-xilinx-2016:
+  - "free-restricted"
+  LicenseRef-scancode-xming:
+  - "commercial"
+  LicenseRef-scancode-xmldb-1.0:
+  - "permissive"
+  LicenseRef-scancode-xxd:
+  - "permissive"
+  LicenseRef-scancode-yahoo-browserplus-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-yahoo-messenger-eula:
+  - "proprietary-free"
+  LicenseRef-scancode-yale-cas:
+  - "permissive"
+  LicenseRef-scancode-yensdesign:
+  - "permissive"
+  LicenseRef-scancode-yolo-1.0:
+  - "proprietary-free"
+  LicenseRef-scancode-yolo-2.0:
+  - "proprietary-free"
+  LicenseRef-scancode-zapatec-calendar:
+  - "commercial"
+  LicenseRef-scancode-zeusbench:
+  - "permissive"
+  LicenseRef-scancode-zhorn-stickies:
+  - "proprietary-free"
+  LicenseRef-scancode-zipeg:
+  - "proprietary-free"
+  LicenseRef-scancode-ziplist5-geocode-dup-addendum:
+  - "commercial"
+  LicenseRef-scancode-ziplist5-geocode-enterprise:
+  - "commercial"
+  LicenseRef-scancode-ziplist5-geocode-workstation:
+  - "commercial"
+  LicenseRef-scancode-zpl-1.0:
+  - "permissive"
+  LicenseRef-scancode-zsh:
+  - "permissive"
+  LicenseRef-scancode-zuora-software:
+  - "permissive"
+  LicenseRef-scancode-zveno-research:
+  - "permissive"
+  Linux-OpenIB:
+  - "permissive"
+  Linux-man-pages-copyleft:
+  - "copyleft"
+  MIT:
+  - "permissive"
+  MIT-0:
+  - "permissive"
+  MIT-CMU:
+  - "permissive"
+  MIT-Modern-Variant:
+  - "permissive"
+  MIT-advertising:
+  - "permissive"
+  MIT-enna:
+  - "permissive"
+  MIT-feh:
+  - "permissive"
+  MIT-open-group:
+  - "permissive"
+  MITNFA:
+  - "permissive"
+  MPL-1.0:
+  - "copyleft-limited"
+  MPL-1.1:
+  - "copyleft-limited"
+  MPL-2.0:
+  - "copyleft-limited"
+  MPL-2.0-no-copyleft-exception:
+  - "copyleft-limited"
+  MS-PL:
+  - "permissive"
+  MS-RL:
+  - "copyleft-limited"
+  MTLL:
+  - "permissive"
+  MakeIndex:
+  - "copyleft"
+  MirOS:
+  - "permissive"
+  Motosoto:
+  - "copyleft"
+  MulanPSL-1.0:
+  - "permissive"
+  MulanPSL-2.0:
+  - "permissive"
+  Multics:
+  - "permissive"
+  Mup:
+  - "permissive"
+  NAIST-2003:
+  - "permissive"
+  NASA-1.3:
+  - "copyleft-limited"
+  NBPL-1.0:
+  - "copyleft-limited"
+  NCGL-UK-2.0:
+  - "free-restricted"
+  NCSA:
+  - "permissive"
+  NGPL:
+  - "copyleft-limited"
+  NIST-PD:
+  - "public-domain"
+  NIST-PD-fallback:
+  - "permissive"
+  NLOD-1.0:
+  - "permissive"
+  NLOD-2.0:
+  - "permissive"
+  NLPL:
+  - "public-domain"
+  NOSL:
+  - "copyleft-limited"
+  NPL-1.0:
+  - "copyleft-limited"
+  NPL-1.1:
+  - "copyleft-limited"
+  NPOSL-3.0:
+  - "copyleft"
+  NRL:
+  - "permissive"
+  NTP:
+  - "permissive"
+  NTP-0:
+  - "permissive"
+  Naumen:
+  - "permissive"
+  Net-SNMP:
+  - "permissive"
+  NetCDF:
+  - "permissive"
+  Newsletr:
+  - "permissive"
+  Nokia:
+  - "copyleft-limited"
+  Noweb:
+  - "copyleft-limited"
+  O-UDA-1.0:
+  - "permissive"
+  OCCT-PL:
+  - "copyleft-limited"
+  OCLC-2.0:
+  - "copyleft-limited"
+  ODC-By-1.0:
+  - "permissive"
+  ODbL-1.0:
+  - "copyleft"
+  OFL-1.0:
+  - "permissive"
+  OFL-1.0-RFN:
+  - "permissive"
+  OFL-1.0-no-RFN:
+  - "permissive"
+  OFL-1.1:
+  - "permissive"
+  OFL-1.1-RFN:
+  - "permissive"
+  OFL-1.1-no-RFN:
+  - "permissive"
+  OGC-1.0:
+  - "permissive"
+  OGDL-Taiwan-1.0:
+  - "permissive"
+  OGL-Canada-2.0:
+  - "permissive"
+  OGL-UK-1.0:
+  - "permissive"
+  OGL-UK-2.0:
+  - "permissive"
+  OGL-UK-3.0:
+  - "permissive"
+  OGTSL:
+  - "copyleft-limited"
+  OLDAP-1.1:
+  - "copyleft-limited"
+  OLDAP-1.2:
+  - "copyleft-limited"
+  OLDAP-1.3:
+  - "copyleft-limited"
+  OLDAP-1.4:
+  - "copyleft-limited"
+  OLDAP-2.0:
+  - "permissive"
+  OLDAP-2.0.1:
+  - "permissive"
+  OLDAP-2.1:
+  - "permissive"
+  OLDAP-2.2:
+  - "permissive"
+  OLDAP-2.2.1:
+  - "permissive"
+  OLDAP-2.2.2:
+  - "permissive"
+  OLDAP-2.3:
+  - "permissive"
+  OLDAP-2.4:
+  - "permissive"
+  OLDAP-2.5:
+  - "permissive"
+  OLDAP-2.6:
+  - "permissive"
+  OLDAP-2.7:
+  - "permissive"
+  OLDAP-2.8:
+  - "permissive"
+  OML:
+  - "permissive"
+  OPL-1.0:
+  - "copyleft-limited"
+  OPUBL-1.0:
+  - "permissive"
+  OSET-PL-2.1:
+  - "copyleft-limited"
+  OSL-1.0:
+  - "copyleft"
+  OSL-1.1:
+  - "copyleft"
+  OSL-2.0:
+  - "copyleft"
+  OSL-2.1:
+  - "copyleft"
+  OSL-3.0:
+  - "copyleft"
+  OpenSSL:
+  - "permissive"
+  PDDL-1.0:
+  - "public-domain"
+  PHP-3.0:
+  - "permissive"
+  PHP-3.01:
+  - "permissive"
+  PSF-2.0:
+  - "permissive"
+  Parity-6.0.0:
+  - "copyleft"
+  Parity-7.0.0:
+  - "copyleft"
+  Plexus:
+  - "permissive"
+  PolyForm-Noncommercial-1.0.0:
+  - "source-available"
+  PolyForm-Small-Business-1.0.0:
+  - "source-available"
+  PostgreSQL:
+  - "permissive"
+  Python-2.0:
+  - "permissive"
+  QPL-1.0:
+  - "copyleft-limited"
+  Qhull:
+  - "copyleft-limited"
+  RHeCos-1.1:
+  - "copyleft"
+  RPL-1.1:
+  - "copyleft-limited"
+  RPL-1.5:
+  - "copyleft-limited"
+  RPSL-1.0:
+  - "copyleft-limited"
+  RSA-MD:
+  - "permissive"
+  RSCPL:
+  - "copyleft-limited"
+  Rdisc:
+  - "permissive"
+  Ruby:
+  - "copyleft-limited"
+  SAX-PD:
+  - "public-domain"
+  SCEA:
+  - "permissive"
+  SGI-B-1.0:
+  - "free-restricted"
+  SGI-B-1.1:
+  - "permissive"
+  SGI-B-2.0:
+  - "permissive"
+  SHL-0.5:
+  - "permissive"
+  SHL-0.51:
+  - "permissive"
+  SISSL:
+  - "proprietary-free"
+  SISSL-1.2:
+  - "proprietary-free"
+  SMLNJ:
+  - "permissive"
+  SMPPL:
+  - "copyleft-limited"
+  SNIA:
+  - "copyleft"
+  SPL-1.0:
+  - "copyleft-limited"
+  SSH-OpenSSH:
+  - "permissive"
+  SSH-short:
+  - "permissive"
+  SSPL-1.0:
+  - "source-available"
+  SWL:
+  - "permissive"
+  Saxpath:
+  - "permissive"
+  SchemeReport:
+  - "permissive"
+  Sendmail:
+  - "permissive"
+  Sendmail-8.23:
+  - "copyleft-limited"
+  SimPL-2.0:
+  - "copyleft"
+  Sleepycat:
+  - "copyleft"
+  Spencer-86:
+  - "permissive"
+  Spencer-94:
+  - "permissive"
+  Spencer-99:
+  - "permissive"
+  SugarCRM-1.1.3:
+  - "copyleft"
+  TAPR-OHL-1.0:
+  - "copyleft-limited"
+  TCL:
+  - "permissive"
+  TCP-wrappers:
+  - "permissive"
+  TMate:
+  - "copyleft"
+  TORQUE-1.1:
+  - "copyleft-limited"
+  TOSL:
+  - "copyleft"
+  TU-Berlin-1.0:
+  - "permissive"
+  TU-Berlin-2.0:
+  - "permissive"
+  UCL-1.0:
+  - "copyleft-limited"
+  UPL-1.0:
+  - "permissive"
+  Unicode-DFS-2015:
+  - "permissive"
+  Unicode-DFS-2016:
+  - "permissive"
+  Unicode-TOU:
+  - "proprietary-free"
+  Unlicense:
+  - "public-domain"
+  VOSTROM:
+  - "copyleft"
+  VSL-1.0:
+  - "permissive"
+  Vim:
+  - "copyleft"
+  W3C:
+  - "permissive"
+  W3C-19980720:
+  - "permissive"
+  W3C-20150513:
+  - "permissive"
+  WTFPL:
+  - "public-domain"
+  Watcom-1.0:
+  - "proprietary-free"
+  Wsuipa:
+  - "permissive"
+  X11:
+  - "permissive"
+  X11-distribute-modifications-variant:
+  - "permissive"
+  XFree86-1.1:
+  - "permissive"
+  XSkat:
+  - "permissive"
+  Xerox:
+  - "permissive"
+  Xnet:
+  - "permissive"
+  YPL-1.0:
+  - "copyleft-limited"
+  YPL-1.1:
+  - "copyleft"
+  ZPL-1.1:
+  - "permissive"
+  ZPL-2.0:
+  - "permissive"
+  ZPL-2.1:
+  - "permissive"
+  Zed:
+  - "permissive"
+  Zend-2.0:
+  - "permissive"
+  Zimbra-1.3:
+  - "copyleft-limited"
+  Zimbra-1.4:
+  - "copyleft-limited"
+  Zlib:
+  - "permissive"
+  blessing:
+  - "public-domain"
+  bzip2-1.0.6:
+  - "permissive"
+  copyleft-next-0.3.0:
+  - "copyleft"
+  copyleft-next-0.3.1:
+  - "copyleft"
+  curl:
+  - "permissive"
+  diffmark:
+  - "public-domain"
+  dvipdfm:
+  - "permissive"
+  eGenix:
+  - "permissive"
+  etalab-2.0:
+  - "permissive"
+  gSOAP-1.3b:
+  - "copyleft-limited"
+  gnuplot:
+  - "copyleft-limited"
+  iMatix:
+  - "permissive"
+  libpng-2.0:
+  - "permissive"
+  libselinux-1.0:
+  - "public-domain"
+  libtiff:
+  - "permissive"
+  mpich2:
+  - "permissive"
+  mplus:
+  - "permissive"
+  psfrag:
+  - "permissive"
+  psutils:
+  - "permissive"
+  wxWindows:
+  - "copyleft-limited"
+  xinetd:
+  - "permissive"
+  xpp:
+  - "permissive"
+  zlib-acknowledgement:
+  - "permissive"

--- a/tools/curations/build.gradle.kts
+++ b/tools/curations/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.ossreviewtoolkit.tools.curations.GenerateAspNetCoreCurationsTask
 import org.ossreviewtoolkit.tools.curations.GenerateAzureSdkForNetCurationsTask
 import org.ossreviewtoolkit.tools.curations.GenerateDotNetRuntimeCurationsTask
+import org.ossreviewtoolkit.tools.curations.GenerateLicenseClassificationsTask
 import org.ossreviewtoolkit.tools.curations.VerifyPackageConfigurationsTask
 import org.ossreviewtoolkit.tools.curations.VerifyPackageCurationsTask
 
 tasks {
+    register<GenerateLicenseClassificationsTask>("generateLicenseClassifications")
     register<GenerateAspNetCoreCurationsTask>("generateAspNetCoreCurations")
     register<GenerateAzureSdkForNetCurationsTask>("generateAzureSdkForNetCurations")
     register<GenerateDotNetRuntimeCurationsTask>("generateDotNetRuntimeCurations")

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateLicenseClassificationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateLicenseClassificationsTask.kt
@@ -1,0 +1,20 @@
+package org.ossreviewtoolkit.tools.curations
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class GenerateLicenseClassificationsTask : DefaultTask() {
+    init {
+        group = "generate license classifications"
+        description = "Generates 'license-classifications.yml' from ScanCode's license database available hosted at " +
+                "https://scancode-licensedb.aboutcode.org."
+    }
+
+    @TaskAction
+    fun generate() {
+        project.rootDir.resolve("../../license-classifications.yml").apply {
+            writeText(generateLicenseClassificationsYaml())
+            logger.quiet("Wrote license classifications to '$absolutePath'.")
+        }
+    }
+}

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -1,0 +1,171 @@
+package org.ossreviewtoolkit.tools.curations
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import kotlin.system.measureTimeMillis
+
+import org.gradle.api.logging.Logging
+import org.ossreviewtoolkit.model.licenses.LicenseCategorization
+import org.ossreviewtoolkit.model.licenses.LicenseCategory
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+
+private val LOGGER = Logging.getLogger("utils")
+private val INDEX_JSON_URL =  "https://scancode-licensedb.aboutcode.org/index.json"
+private val JSON_MAPPER = JsonMapper().apply {
+    KotlinModule.Builder()
+        .configure(KotlinFeature.NullIsSameAsDefault, true)
+        .build()
+        .let { registerModule(it) }
+
+    propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+}
+private val DISCLAIMER_TEXT = """
+This ORT configuration file is provided as an example only. It
+demonstrates the general configuration capabilities of ORT and does not
+reflect any real-world configuration used by the ORT contributors, nor
+are they a recommendation on the configuration to use.
+
+Please consult your legal counsel about how ORT should be configured for your use cases.
+"""
+
+private data class License(
+    val licenseKey: String,
+    val spdxLicenseKey: String? = null,
+    val otherSpdxLicenseKeys: List<String> = emptyList(),
+    val isException: Boolean,
+    val isDeprecated: Boolean,
+    val json: String,
+    val yml: String,
+    val html: String,
+    val text: String
+)
+
+private data class LicenseDetails(
+    val key: String,
+    val shortName: String,
+    val name: String,
+    val category: String,
+    val owner: String,
+    val homepageUrl: String? = null,
+    val notes: String? = null,
+    val spdxLicenseKey: String? = null,
+    val minimumCoverage: Int? = null,
+    val standardNotice: String? = null,
+    val isDeprecated: Boolean = false,
+    val isException: Boolean = false,
+    val isGeneric: Boolean = false,
+    val isUnknown: Boolean = false,
+    val ignorableCopyrights: List<String> = emptyList(),
+    val ignorableHolders: List<String> = emptyList(),
+    val ignorableAuthors: List<String> = emptyList(),
+    val ignorableEmails: List<String> = emptyList(),
+    val ignorableUrls: List<String> = emptyList(),
+    val textUrls: List<String> = emptyList(),
+    val otherUrls: List<String> = emptyList(),
+    val faqUrl: String? = null,
+    val osiLicenseKey: String? = null,
+    val otherSpdxLicenseKeys: List<String> = emptyList(),
+    val osiUrl: String? = null,
+    val language: String? = null
+)
+
+private fun downloadLicenseIndex(): List<License> =
+    JSON_MAPPER.readValue<List<License>>(URL(INDEX_JSON_URL))
+
+private fun downloadLicenseDetails(license: License): LicenseDetails {
+    val url = INDEX_JSON_URL.substringBeforeLast("/") + "/${license.json}"
+    LOGGER.info("GET $url.")
+    return JSON_MAPPER.readValue<LicenseDetails>(URL(url))
+}
+
+private fun downloadLicenseDetailsAsync(
+    licenses: Collection<License>,
+    threadCount: Int = 60
+): Map<License, LicenseDetails> {
+    val queue = ConcurrentLinkedQueue(licenses)
+    val result = ConcurrentHashMap<License, LicenseDetails>()
+
+    val threads = List(threadCount) { _ ->
+        Thread {
+            var license = queue.poll()
+
+            while (license != null) {
+                result[license] = downloadLicenseDetails(license)
+                license = queue.poll()
+            }
+        }
+    }
+
+    val executionTimeMillis = measureTimeMillis {
+        threads.run {
+            forEach { it.start() }
+            forEach { it.join() }
+        }
+    }
+
+    LOGGER.quiet("Downloaded ${result.size} files in ${executionTimeMillis / 1000f} seconds on $threadCount threads.")
+
+    return result.toMap()
+}
+
+private fun LicenseDetails.getLicenseId(): SpdxSingleLicenseExpression {
+    val expression = spdxLicenseKey ?: otherSpdxLicenseKeys.firstOrNull() ?: "LicenseRef-scancode-${key}"
+    return SpdxSingleLicenseExpression.parse(expression)
+}
+
+private fun LicenseDetails.getCategories(): Set<String> =
+    // TODO: Check if the category "Unstated License" could additionally be used by below mapping to move
+    // license IDs which do no correspond to "normal" licenses to separate categories.
+    when {
+        isUnknown -> "unknown"
+        isGeneric -> "generic"
+        else -> category
+    }.let { setOf(it.replace(' ', '-').toLowerCase()) }
+
+private fun getLicenseClassifications(licenseDetails: Collection<LicenseDetails>) =
+    LicenseClassifications(
+        categories = licenseDetails.flatMap { it.getCategories() }.distinct().map {
+            LicenseCategory(it)
+        }.sortedBy { it.name },
+        categorizations = licenseDetails.map {
+            LicenseCategorization(
+                id = it.getLicenseId(),
+                categories = it.getCategories()
+            )
+        }.sortedBy { it.id.toString() }
+    )
+
+/**
+ * Generate license classifications from ScanCode's license categories.
+ *
+ * The original categories are used except for 'unknown' and 'generic' licenses, which are assigned to a separate
+ * category.
+ */
+fun generateLicenseClassificationsYaml(): String {
+    val licenses = downloadLicenseIndex().filterNot {
+        it.isException || it.licenseKey == "x11-xconsortium_veillard"
+    }
+    val licenseDetails = downloadLicenseDetailsAsync(licenses).values
+    val licenseClassifications = getLicenseClassifications(licenseDetails)
+
+    licenseClassifications.run {
+        LOGGER.quiet(
+            "Generated a license classification with ${categorizations.size} license and ${categories.size} categories."
+        )
+    }
+
+    val yaml = yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(licenseClassifications)
+    val disclaimer = DISCLAIMER_TEXT.split('\n').map { "# $it".trim() }.joinToString("\n")
+
+    return "$disclaimer\n$yaml"
+}


### PR DESCRIPTION
These tasks don't need to be abstract as they don't have any abstract functions. So, drop the `abstract` keyword in favor of `open`, as Gradle tasks are required to be non-final.

Part of #59.


