### PR TITLE
license-classification: Drop the redundant 'strong-copyleft' category

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -11,7 +11,6 @@
 
 categories:
 - name: "copyleft"
-- name: "strong-copyleft"
 - name: "copyleft-limited"
 - name: "permissive"
   description: "Licenses with permissive obligations."
@@ -316,7 +315,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "PSF"
   categories:
-  - "strong-copyleft"
+  - "copyleft"
   - "include-in-notice-file"
 - id: "Python-2.0"
   categories:


### PR DESCRIPTION
The categories 'copyleft' and 'strong-copyleft' have identical semantics, while 'copyleft' has more usages and aligns with ScanCode's category name. So, align on using 'copyleft' as category for "Strong Copyleft" licenses.

Part of #59.

