### PR TITLE
tools/curations: Make several Gradle tasks non-abstract

### DIFF
--- a/tools/curations/buildSrc/src/main/kotlin/AbstractGenerateCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/AbstractGenerateCurationsTask.kt
@@ -18,7 +18,7 @@ import org.ossreviewtoolkit.model.mapperConfig
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import java.io.IOException
 
-abstract class AbstractGenerateCurationsTask : DefaultTask() {
+open class AbstractGenerateCurationsTask : DefaultTask() {
     private val githubUsername: String by project
     private val githubToken: String by project
 

--- a/tools/curations/buildSrc/src/main/kotlin/BaseGenerateCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/BaseGenerateCurationsTask.kt
@@ -18,7 +18,7 @@ import org.ossreviewtoolkit.model.mapperConfig
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import java.io.IOException
 
-open class AbstractGenerateCurationsTask : DefaultTask() {
+open class BaseGenerateCurationsTask : DefaultTask() {
     private val githubUsername: String by project
     private val githubToken: String by project
 

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateAspNetCoreCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateAspNetCoreCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-abstract class GenerateAspNetCoreCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateAspNetCoreCurationsTask : AbstractGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         val data = mutableListOf<PathCurationData>()

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateAspNetCoreCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateAspNetCoreCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-open class GenerateAspNetCoreCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateAspNetCoreCurationsTask : BaseGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         val data = mutableListOf<PathCurationData>()

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateAzureSdkForNetCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateAzureSdkForNetCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-abstract class GenerateAzureSdkForNetCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateAzureSdkForNetCurationsTask : AbstractGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         getFilesFromRepository(owner = "Azure", repository = "azure-sdk-for-net")

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateAzureSdkForNetCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateAzureSdkForNetCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-open class GenerateAzureSdkForNetCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateAzureSdkForNetCurationsTask : BaseGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         getFilesFromRepository(owner = "Azure", repository = "azure-sdk-for-net")

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateDotNetRuntimeCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateDotNetRuntimeCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-abstract class GenerateDotNetRuntimeCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateDotNetRuntimeCurationsTask : AbstractGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         val data = mutableListOf<PathCurationData>()

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateDotNetRuntimeCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateDotNetRuntimeCurationsTask.kt
@@ -3,7 +3,7 @@ package org.ossreviewtoolkit.tools.curations
 import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.Identifier
 
-open class GenerateDotNetRuntimeCurationsTask : AbstractGenerateCurationsTask() {
+open class GenerateDotNetRuntimeCurationsTask : BaseGenerateCurationsTask() {
     @TaskAction
     fun generate() {
         val data = mutableListOf<PathCurationData>()

--- a/tools/curations/buildSrc/src/main/kotlin/VerifyPackageConfigurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/VerifyPackageConfigurationsTask.kt
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.TaskAction
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.mapper
 
-abstract class VerifyPackageConfigurationsTask : DefaultTask() {
+open class VerifyPackageConfigurationsTask : DefaultTask() {
     init {
         group = "verification"
     }

--- a/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
@@ -9,7 +9,7 @@ import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.mapper
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
-abstract class VerifyPackageCurationsTask : DefaultTask() {
+open class VerifyPackageCurationsTask : DefaultTask() {
     init {
         group = "verification"
     }


### PR DESCRIPTION
These tasks don't need to be abstract as they don't have any abstract functions. So, drop the `abstract` keyword in favor of `open`, as Gradle tasks are required to be non-final.
