### PR TITLE
evaluator-rules: Fix-up a compilation error

### DIFF
--- a/evaluator-rules/src/main/resources/example.rules.kts
+++ b/evaluator-rules/src/main/resources/example.rules.kts
@@ -1065,7 +1065,7 @@ fun RuleSet.copyleftLimitedInSourceRule() = packageRule("COPYLEFT_LIMITED_IN_SOU
             "The ScanCode copyleft-limited categorized license $license was $licenseSourceName in package " +
                     "${pkg.metadata.id.toCoordinates()}."
         } else {
-            "The package ${pkg.id.toCoordinates()} has the $licenseSourceName ScanCode copyleft-limited " +
+            "The package ${pkg.metadata.id.toCoordinates()} has the $licenseSourceName ScanCode copyleft-limited " +
                     "categorized license $license."
         }
 


### PR DESCRIPTION
Compilation started to fail as of [1].

[1] https://github.com/oss-review-toolkit/ort-config/commit/35faef661e70c4b81d130ce5afb3eb8de86c62e3
