### PR TITLE
Switch to a generated `license-classifications.yml` based on ScanCode's License DB

### DIFF
--- a/evaluator-rules/gradle/libs.versions.toml
+++ b/evaluator-rules/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "b9e8b63ace"
+ort = "e8c786d3bb"
 
 [libraries]
 ortEvaluator = { module = "com.github.oss-review-toolkit.ort:evaluator", version.ref = "ort" }

--- a/evaluator-rules/src/main/resources/example.rules.kts
+++ b/evaluator-rules/src/main/resources/example.rules.kts
@@ -46,6 +46,9 @@ val publicDomainLicenses = licenseClassifications.licensesByCategory["public-dom
 
 /**
  * The complete set of licenses covered by policy rules.
+ *
+ * // TODO: Update the handled licenses to cover all recently added categories. This requires adding
+ *          policy rules for new (offinding) categories, if any.
  */
 val handledLicenses = listOf(
     permissiveLicenses,

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1,46 +1,71 @@
----
-# Example license-classifications.yml based on categorization from
-# https://github.com/nexB/scancode-toolkit/commit/ed644e4.
 #
-# To demonstrate how one can insert a custom written offer
-# include-source-code-offer-in-notice-file has been set to
-# true for all licenses of the GPL family.
+# License classification generated based on https://scancode-licensedb.aboutcode.org/.
+#
+# This ORT configuration file is provided as an example only. It
+# demonstrates the general configuration capabilities of ORT and does not
+# reflect any real-world configuration used by the ORT contributors, nor
+# are they a recommendation on the configuration to use.
+#
+# Please consult your legal counsel about how ORT should be configured for your use cases.
 #
 # For detailed documentation on this file, see
 # https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-license-classifications-yml.md.
-
+#
+---
 categories:
+- name: "commercial"
 - name: "copyleft"
 - name: "copyleft-limited"
-- name: "permissive"
-  description: "Licenses with permissive obligations."
-- name: "public-domain"
+- name: "free-restricted"
+- name: "generic"
 - name: "include-in-notice-file"
-  description: >-
-    This category is checked by templates used by the ORT report generator. The licenses associated with this
-    category are included into NOTICE files.
 - name: "include-source-code-offer-in-notice-file"
-  description: >-
-    A marker category that indicates that the licenses assigned to it require that the source code of the packages
-    needs to be provided.
-
+- name: "patent-license"
+- name: "permissive"
+- name: "proprietary-free"
+- name: "public-domain"
+- name: "source-available"
+- name: "unknown"
+- name: "unstated-license"
 categorizations:
-- id: "AGPL-1.0"
+- id: "0BSD"
   categories:
-  - "copyleft"
+  - "permissive"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+- id: "AAL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ADSL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AFL-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AFL-1.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AFL-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AFL-2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AFL-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "AGPL-1.0-only"
   categories:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
 - id: "AGPL-1.0-or-later"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "AGPL-3.0"
   categories:
   - "copyleft"
   - "include-in-notice-file"
@@ -55,18 +80,117 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "AMDPLPA"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AML"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "AMPAS"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ANTLR-PD"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ANTLR-PD-fallback"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "APAFML"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "APL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "APSL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "APSL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "APSL-1.2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "APSL-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Abstyles"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Adobe-2006"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Adobe-Glyph"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Afmparse"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Aladdin"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Apache-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Apache-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "Apache-2.0"
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "App-s2p"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Arphic-1999"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Artistic-1.0"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Artistic-1.0-Perl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Artistic-1.0-cl8"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Artistic-2.0"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "BSD-1-Clause"
   categories:
   - "permissive"
@@ -75,11 +199,11 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "BSD-2-Clause-FreeBSD"
+- id: "BSD-2-Clause-Patent"
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "BSD-2-Clause-NetBSD"
+- id: "BSD-2-Clause-Views"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -87,7 +211,47 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "BSD-3-Clause-Attribution"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-Clear"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-LBNL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-Modification"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-No-Military-License"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-No-Nuclear-License"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-No-Nuclear-License-2014"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-No-Nuclear-Warranty"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "BSD-3-Clause-Open-MPI"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "BSD-4-Clause"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-4-Clause-Shortened"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -95,6 +259,80 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "BSD-Protection"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "BSD-Source-Code"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BUSL-1.1"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "Baekmuk"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Bahyph"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Barr"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Beerware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BitTorrent-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "BitTorrent-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Bitstream-Vera"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BlueOak-1.0.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Borceux"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "C-UDA-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "CAL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CAL-1.0-Combined-Work-Exception"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CATOSL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "CC-BY-1.0"
   categories:
   - "permissive"
@@ -107,13 +345,194 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "CC-BY-2.5-AU"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "CC-BY-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CC-BY-3.0-AT"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CC-BY-3.0-DE"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CC-BY-3.0-NL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CC-BY-3.0-US"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "CC-BY-4.0"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-2.5"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-3.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-3.0-DE"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-4.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-2.5"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-3.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-3.0-DE"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-3.0-IGO"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-ND-4.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-2.0-FR"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-2.0-UK"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-2.5"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-3.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-3.0-DE"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-3.0-IGO"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-NC-SA-4.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-2.5"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-3.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-3.0-DE"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "CC-BY-ND-4.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "CC-BY-SA-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-2.0-UK"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-2.1-JP"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-2.5"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-3.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-3.0-AT"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-3.0-DE"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-BY-SA-4.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CC-PDDC"
+  categories:
+  - "public-domain"
   - "include-in-notice-file"
 - id: "CC0-1.0"
   categories:
@@ -123,31 +542,379 @@ categorizations:
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "CDDL-1.1"
   categories:
   - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CDL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CDLA-Permissive-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CDLA-Permissive-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CDLA-Sharing-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CECILL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CECILL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CECILL-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CECILL-2.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CECILL-B"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CECILL-C"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CERN-OHL-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CERN-OHL-1.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CERN-OHL-P-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CERN-OHL-S-2.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CERN-OHL-W-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CNRI-Jython"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CNRI-Python"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CNRI-Python-GPL-Compatible"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "COIL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CPAL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "CPOL-1.02"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "CUA-OPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Caldera"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ClArtistic"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Community-Spec-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Condor-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Crossword"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "CrystalStacker"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Cube"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "D-FSL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "DL-DE-BY-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "DOC"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "DRL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "DSDP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Dotseqn"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ECL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ECL-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "EFL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "EFL-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "EPICS"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "EPL-1.0"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "EPL-2.0"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
-- id: "EUPL-1.1"
+  - "include-source-code-offer-in-notice-file"
+- id: "EUDatagrid"
   categories:
-  - "copyleft-limited"
+  - "permissive"
   - "include-in-notice-file"
-- id: "EUPL-1.2"
-  categories:
-  - "copyleft-limited"
-  - "include-in-notice-file"
-- id: "GPL-1.0+"
+- id: "EUPL-1.0"
   categories:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "EUPL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "EUPL-1.2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Elastic-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "Entessa"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ErlPL-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Eurosym"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "FDK-AAC"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "FSFAP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "FSFUL"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "FSFULLR"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "FTL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Fair"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Frameworx-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "FreeBSD-DOC"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "FreeImage"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GD"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "GFDL-1.1-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.1-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.1-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.1-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.1-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.1-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.2-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-no-invariants-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-no-invariants-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-only"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GFDL-1.3-or-later"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GL2PS"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "GLWTPL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "GPL-1.0-only"
   categories:
   - "copyleft"
@@ -158,42 +925,12 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0+"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only"
   categories:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0-only WITH Classpath-exception-2.0"
-  categories:
-  - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-2.0-only WITH Font-exception-2.0"
-  categories:
-  - "copyleft-limited"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-or-later"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-3.0"
-  categories:
-  - "copyleft"
-  - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
-- id: "GPL-3.0+"
   categories:
   - "copyleft"
   - "include-in-notice-file"
@@ -208,7 +945,92 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "Giftware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Glide"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Glulxe"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "HPND"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "HPND-sell-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "HTMLTIDY"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "HaskellReport"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Hippocratic-2.1"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "IBM-pibs"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ICU"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "IJG"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "IPA"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "IPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "ISC"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ImageMagick"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Imlib2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Info-ZIP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Intel"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Intel-ACPI"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Interbase-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "JPNIC"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -216,10 +1038,34 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "Jam"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "JasPer-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "KiCad-libraries-exception"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LAL-1.2"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LAL-1.3"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.0-only"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LGPL-2.0-or-later"
   categories:
   - "copyleft-limited"
@@ -245,10 +1091,5471 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LGPLLR"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPL-1.02"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPPL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPPL-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPPL-1.2"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPPL-1.3a"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LPPL-1.3c"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Latex2e"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Leptonica"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LiLiQ-P-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LiLiQ-R-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LiLiQ-Rplus-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Libpng"
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-.amazon.com.-AmznSL-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-3com-microcode"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-3dslicer-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-4suite-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-996-icu-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-Hippocratic-3.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-abrms"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ac3filter"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-accellera-systemc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-acroname-bdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-activestate-community"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-activestate-community-2012"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-activestate-komodo-edit"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-actuate-birt-ihub-ftype-sla"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adaptec-downloadable"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adaptec-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-addthis-mobile-sdk-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adi-bsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-acrobat-reader-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-air-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-air-sdk-2014"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-color-profile-bundling"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-color-profile-license"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-dng-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-dng-spec-patent"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-flash-player-eula-21.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-flex-4-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-flex-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-general-tou"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-indesign-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-postscript"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-adrian"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aes-128-3.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-afpl-9.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-agentxpp"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-agere-bsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-agere-sla"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ago-private-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-agpl-2.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-aladdin-md5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-alasir"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-alexisisaac-freeware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-allen-institute-software-2018"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-altermime"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-altova-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-amazon-redshift-jdbc"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-amd-historical"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-amd-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-amd-linux-firmware-export"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-amlogic-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ams-fonts"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-android-sdk-2009"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-android-sdk-2012"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-android-sdk-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-android-sdk-license"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-android-sdk-preview-2015"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-anepokis-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-anti-capitalist-1.4"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-anu-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aop-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apache-due-credit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apl-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-appfire-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-attribution"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-attribution-1997"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-excl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-mfi-license"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-mpeg-4"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-apple-sscl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-appsflyer-framework"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aptana-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-arachni-psl-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aravindan-premkumar"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-argouml"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-arm-cortex-mx"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-arm-llvm-sga"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-array-input-method-pl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-artistic-1988-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-aslp"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aslr"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-asmus"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-asn1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ati-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atkinson-hyperlegible-font"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atlassian-marketplace-tou"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atmel-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atmel-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atmel-microcontroller"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-atmosphere-0.4"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-autoit-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bakoma-fonts-1995"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bapl-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bea-2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-beal-screamer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bigdigits"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bigelow-holmes"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-binary-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-binary-linux-firmware-patent"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-biopython"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-biosl-4.0"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bittorrent-1.2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-bittorrent-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bitwarden-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bitzi-pd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-blas-2017"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-blitz-artistic"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-bloomberg-blpapi"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bohl-0.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-boost-original"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bpel4ws-spec"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bpmn-io"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brad-martinez-vb-32"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brent-corkum"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brian-clapper"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brian-gladman"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brian-gladman-3-clause"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brian-gladman-dual"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-cfe"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-confidential"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-dual"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-linux-timer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-proprietary"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-raspberry-pi"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-standard-terms"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-unpublished-source"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadcom-wiced"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-broadleaf-fair-use"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brocade-firmware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bruno-podetti"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-1-clause-build"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-1988"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-2-clause-freebsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-2-clause-netbsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-2-clause-plus-advertizing"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-devine"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-fda"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-jtag"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-no-change"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-no-trademark"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-sun"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-ack-carrot2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-artwork"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-atmel"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-axis"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-axis-nomod"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-credit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-dpt"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-export"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-innosys"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-intel"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-mylex"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-new-derivative"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-new-nomod"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-new-tcpdump"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-no-disclaimer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-no-disclaimer-unmodified"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-no-mod"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-original-muscle"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-original-uc-1986"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-original-uc-1990"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-original-voices"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-plus-mod-notice"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-simplified-darwin"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-simplified-intel"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-simplified-source"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-top"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-top-gpl-addition"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-unchanged"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-unmodified"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-x11"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsl-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsla"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsla-no-advert"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bugsense-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bytemark"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bzip2-libbzip-1.0.5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-c-fsl-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cadence-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-can-ogl-alberta-2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-can-ogl-british-columbia-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-can-ogl-nova-scotia-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-can-ogl-ontario-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-can-ogl-toronto-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-careware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-carnegie-mellon"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-carnegie-mellon-contributors"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cavium-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cavium-malloc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cavium-targeted-hardware"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-by-2.0-uk"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-by-nc-nd-2.0-at"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-by-nc-nd-2.0-au"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-by-nc-sa-3.0-us"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-devnations-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-gpl-2.0-pt"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cc-lgpl-2.1-pt"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cc-nc-sampling-plus-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-pdm-1.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-sampling-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cc-sampling-plus-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cclrc"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ccrc-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cecill-1.0-en"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cecill-2.0-fr"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cecill-2.1-fr"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cecill-b-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cecill-c-en"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cern-attribution-1995"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cgic"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-chartdirector-6.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-chelsio-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-chicken-dl-0.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-chris-maunder"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-chris-stoy"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-christopher-velazquez"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-classic-vb"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-classworlds"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-clear-bsd-1-clause"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-click-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cloudera-express"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmigemo"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmr-no"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmu-computing-services"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmu-mit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmu-simple"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cmu-template"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cncf-corporate-cla-1.0"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cncf-individual-cla-1.0"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cockroach"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-code-credit-license-1.0.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-codeguru-permissions"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-codesourcery-2004"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-codexia"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cognitive-web-osl-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-colt"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-com-oreilly-servlet"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-commercial-license"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-commercial-option"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-commonj-timer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-compass"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-componentace-jcraft"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-concursive-pl-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-confluent-community-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cooperative-non-violent-4.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-copyheart"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-corporate-accountability-1.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cosl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cosli"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-couchbase-community"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-couchbase-enterprise"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cpl-0.5"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cpm-2022"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cpol-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cpp-core-guidelines"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-crapl-0.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-crashlytics-agreement-2018"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-crcalc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-crypto-keys-redistribution"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cryptopp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-csla"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-csprng"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ctl-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cubiware-software-1.0"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cups"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cve-tou"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cvwl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cwe-tou"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cximage"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-cypress-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-d-fsl-1.0-en"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-d-zlib"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-damail"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dante-treglia"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-datamekanix-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-day-spec"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dbad"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dbad-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dbcl-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-dco-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-defensive-patent-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-dejavu-font"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-delorie-historical"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dennis-ferguson"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-devblocks-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-dgraph-cla"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dhtmlab-public"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-digia-qt-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-digia-qt-preview"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-divx-open-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-divx-open-2.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-dl-de-by-1-0-de"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dl-de-by-1-0-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dl-de-by-2-0-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dl-de-by-nc-1-0-de"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dl-de-by-nc-1-0-en"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dmalloc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-do-no-harm-0.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-docbook"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dos32a-extender"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-doug-lea"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-douglas-young"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dpl-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-dr-john-maddock"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dropbear"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dropbear-2016"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dtree"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dual-bsd-gpl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dual-commercial-gpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-duende-sla-2022"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dwtfnmfpl-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dynamic-drive-tou"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dynarch-developer"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dynarch-linkware"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecfonts-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2001"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2002"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2003"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2004"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2005"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2010"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2011"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2014"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2014-11"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eclipse-sua-2017"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ecma-documentation"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecma-patent-coc-0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecma-patent-coc-1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecma-patent-coc-2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecosrh-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-efsl-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-egenix-1.0.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-egrappler"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ej-technologies-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ekioh"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-elastic-license-2018"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-elib-gpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ellis-lab"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-emit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-emx-library"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-energyplus-bsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-enhydra-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-epaperpress"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-epo-osl-2005.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-eric-glass"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-esri"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-esri-devkit"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-etalab-2.0-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-etalab-2.0-fr"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-examdiff"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-excelsior-jet-runtime"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fabien-tassin"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fabric-agreement-2017"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-facebook-nuclide"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-facebook-patent-rights-2"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-facebook-software-license"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fair-source-0.9"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fancyzoom"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fastbuild-2012-2020"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fatfs"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fftpack-2004"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-filament-group-mit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-first-works-appreciative-1.2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-flex-2.5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-flex2sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-flora-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-flowplayer-gpl-3.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-font-alias"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-foobar2000"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fpl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fplot"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fraunhofer-iso-14496-10"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-free-art-1.3"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-free-fork"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-free-unknown"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-freebsd-boot"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-freebsd-first"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-freemarker"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-freetts"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-freetype-patent"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-froala-owdl-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-frontier-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-fsf-notice"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-fsf-unlimited-no-warranty"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ftdi"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ftpbean"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gareth-mccaughan"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gary-s-brown"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gcel-2022"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gco-v3.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gdcl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-generic-cla"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-generic-export-compliance"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-generic-tos"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-generic-trademark"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-genivia-gsoap"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-geoff-kuenning-1993"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ghostpdl-permissive"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ghostscript-1988"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gitlab-ee"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gladman-older-rijndael-code"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-glut"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gnu-emacs-gpl-1988"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-goahead"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-good-boy"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-analytics-tos"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-analytics-tos-2015"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-analytics-tos-2016"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-analytics-tos-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-apis-tos-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-cla"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-corporate-cla"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-02-07"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-05-01"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-06-07"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-07-09"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-07-19"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-10-01"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2018-10-31"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2019-05-02"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2019-11-21"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2020-04-02"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2020-04-27"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-maps-tos-2020-05-06"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-ml-kit-tos-2022"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license-fuchsia"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license-fuschia"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license-golang"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license-webm"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-patent-license-webrtc"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-playcore-sdk-tos-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-tos-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-tos-2014"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-tos-2017"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-tos-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-google-tos-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gpl-2.0-adaptec"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gpl-2.0-djvu"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gpl-2.0-koterov"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-graphics-gems"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-greg-roelofs"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gregory-pietsch"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-gsoap-1.3a"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gust-font-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gust-font-2006-09-30"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-gutenberg-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-h2-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-hacos-1.2"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-happy-bunny"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hauppauge-firmware-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hauppauge-firmware-oem"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hazelcast-community-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hdf4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hdf5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hdparm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-helios-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-helix"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-here-disclaimer"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-here-proprietary"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hessla"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hidapi"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hippocratic-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hippocratic-1.1"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hippocratic-1.2"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hippocratic-2.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-historical-ntp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-historical-sell-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-homebrewed"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hot-potato"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-enterprise-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-netperf"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-proliant-essentials"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-snmp-pp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-software-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-ux-java"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hp-ux-jre"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hs-regexp-orig"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-html5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-httpget"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hugo"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hxd"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ian-kaplan"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ian-piumarta"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-as-is"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-data-server-2011"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-developerworks-community"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-dhcp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-icu"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-java-portlet-spec-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-jre"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-nwsc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibm-sample"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ibpp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ic-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ic-shared-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-icann-public"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-icot-free"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-idt-notice"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ietf"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ietf-trust"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ilmid"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-imagen"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-indiana-extreme"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-infineon-free"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-1997-10"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2001-01"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2002-02"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2003-05"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2004-05"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2005-02"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2007-03"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-info-zip-2009-01"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-infonode-1.1"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-initial-developer-public"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-inner-net-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-inno-setup"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-installsite"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-bcl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-bsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-bsd-2-clause"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-code-samples"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-confidential"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-master-eula-sw-dev-2016"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-material"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-mcu-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-microcode"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-osl-1989"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-osl-1993"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-royalty-free"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-sample-source-code-2015"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-scl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iozone"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iptc-2006"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-irfanview-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iso-14496-10"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iso-8879"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iso-recorder"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-isotope-cla"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-issl-2018"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-itc-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-itu"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-itu-t"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-itu-t-gpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-itunes"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ja-sig"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jahia-1.3.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-jam-stapl"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jamon"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jason-mayes"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jasper-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-java-app-stub"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-java-research-1.5"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-java-research-1.6"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jboss-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jdbm-1.00"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jdom"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jelurida-public-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-jetbrains-purchase-terms"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jetbrains-toolbox-oss-3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jetty"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jetty-ccla-1.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jgraph"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jgraph-general"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jide-sla"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jj2000"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jmagnetic"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-josl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-jpnic-mdnkit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jprs-oscl-1.1"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jpython-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jquery-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jrunner"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jscheme"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jsfromhell"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-json-js-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-json-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jsr-107-jcache-spec"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jsr-107-jcache-spec-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-jython"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kalle-kaukonen"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-karl-peterson"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-katharos-0.1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kde-accepted-gpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-kde-accepted-lgpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-keith-rule"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kerberos"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kevan-stannard"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kevlin-henney"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-khronos"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kreative-relay-fonts-free-1.2f"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-kumar-robotics"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-larabie"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lavantech"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lcs-telegraphics"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ldap-sdk-free-use"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ldpc-1994"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpc-1997"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpc-1999"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpgpl-1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpgpl-1a"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpl-2.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ldpm-1998"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-leap-motion-sdk-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lha"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libcap"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libgeotiff"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libmib"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libmng-2007"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libpbm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-librato-exception"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libselinux-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libsrv-1.0.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-libzip"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-license-file-reference"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lil-1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lilo"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-linotype-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-linum"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-linux-device-drivers"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-linuxbios"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-linuxhowtos"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-llgpl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-llnl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-logica-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lontium-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-losla"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-lsi-proprietary-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lucre"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lumisoft-mail-server"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-luxi"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lyubinskiy-dropdown"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lyubinskiy-popup-window"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lzma-sdk-2006"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-lzma-sdk-2008"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-lzma-sdk-original"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-lzma-sdk-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-madwifi-dual"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mame"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-manfred-klein-fonts-tos"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mapbox-tos-2021"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-markus-kuhn-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-martin-birgmeier"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-marvell-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-marvell-firmware-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-matt-gallagher-attribution"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-matthew-kwan"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-matthew-welch-font-license"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mattkruse"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-maxmind-geolite2-eula-2019"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-maxmind-odl"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mcafee-tou"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mcrae-pl-4-r53"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mediainfo-lib"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-melange"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mentalis"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-merit-network-derivative"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-metageek-inssider-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-metrolink-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-mgopen-font-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-michael-barr"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-michigan-disclaimer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-microchip-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-microsoft-windows-rally-devkit"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mike95"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-minecraft-mod"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-minpack"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-1995"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-addition"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-license-1998"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-modification-obligations"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-nagy"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-no-advert-export-control"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-no-trademarks"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-old-style"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-old-style-sparse"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-readme"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-specification-disclaimer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-synopsys"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-taylor-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-veillard-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mit-xfig"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mod-dav-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-monetdb-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-motorola"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-moxa-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mozilla-gc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mozilla-ospl-1.0"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mpeg-7"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mpeg-iso"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mpeg-ssg"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-ajax-supp-terms"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-mvc3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-mvc4"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-mvc4-extensions"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-software"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-tools-pre-release"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-web-optimization"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-web-pages-2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-asp-net-web-pages-templates"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-azure-data-studio"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-azure-spatialanchors-2.9.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-capicom"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-cl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ms-cla"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-control-spy-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-data-tier-af-2022"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-dev-services-2018-06"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-dev-services-agreement"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-device-emulator-3.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-direct3d-d3d120n7-1.1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-directx-sdk-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-dxsdk-d3dx-9.29.952.3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-enterprise-library-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-entity-framework-4.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-entity-framework-5"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-eula-win-script-host"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-exchange-srv-2010-sp2-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-iis-container-eula-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-ilmerge"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-invisible-eula-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-jdbc-driver-40-sql-server"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-jdbc-driver-41-sql-server"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-jdbc-driver-60-sql-server"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-kinext-win-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-limited-community"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-limited-public"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-lpl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-msn-webgrease"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-framework-4-supp-terms"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-framework-deployment"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-library"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-library-2016-05"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-library-2018-11"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-library-2019-06"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-net-library-2020-09"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-nt-resource-kit"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-nuget"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-nuget-package-manager"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-office-extensible-file"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-office-system-programs-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-patent-promise"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-patent-promise-mono"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-permissive-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-platform-sdk"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-programsynthesis-7.22.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-python-vscode-pylance-2021"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-reactive-extensions-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-refl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-remote-ndis-usb-kit"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-research-shared-source"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-rsl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-silverlight-3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-sql-server-compact-4.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-sql-server-data-tools"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-sspl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-sysinternals-sla"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-testplatform-17.0.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-ttf-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-typescript-msbuild-4.1.4"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-2008-runtime"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-2010-runtime"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-2015-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-cpp-2015-runtime"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-studio-2017"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-studio-2017-tools"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-studio-code"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-studio-code-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-visual-studio-code-2022"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-vs-addons-ext-17.2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-web-developer-tools-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-win-container-eula-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-win-sdk-server-2008-net-3.5"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-driver-kit"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-identity-foundation"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-os-2018"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-sdk-win10"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-sdk-win7-net-4"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-server-2003-ddk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-windows-server-2003-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-ws-routing-spec"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-xamarin-uitest3.2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ms-xml-core-4.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-msj-sample-code"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-msntp"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-msppl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mtx-licensing-statement"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mulanpsl-1.0-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mulanpsl-2.0-en"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mule-source-1.1.3"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-mule-source-1.1.4"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-mulle-kybernetik"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mvt-1.1"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mx4j"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-naughter"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ncbi"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nero-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-netapp-sdk-aug2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-netcat"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-netcomponents"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-netron"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-netronome-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-network-time-protocol"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-new-relic"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-newlib-historical"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-newran"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-newton-king-cla"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nexb-eula-saas-1.1.0"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nexb-ssla-1.1.0"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nice"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nicta-psl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-niels-ferguson"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nilsson-historical"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nist-srd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-no-license"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-node-js"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-non-violent-4.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nonexclusive"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nortel-dasa"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-northwoods-sla-2021"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-notre-dame"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nrl-permission"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ntlm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ntpl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ntpl-origin"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-numerical-recipes-notice"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nunit-v2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-2002"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-apex-sdk-eula-2011"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-cuda-supplement-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-gov"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-isaac-eula-2019.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-ngx-eula-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-sdk-eula-v0.11"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-video-codec-agreement"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nwhm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxp-firmware-patent"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxp-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxp-mc-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxp-microctl-proprietary"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxp-warranty-disclaimer"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nysl-0.9982"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nysl-0.9982-jp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-o-young-jong"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oasis-ipr-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oasis-ipr-policy-2014"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oasis-ws-security-spec"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ocb-non-military-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ocb-open-source-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ocb-patent-openssl-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oclc-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ocsl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-oculus-sdk"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-oculus-sdk-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oculus-sdk-3.5"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-odc-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-odl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-odmg"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogc-2006"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogc-document-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogl-1.0a"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogl-canada-2.0-fr"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ogl-wpd-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ohdl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-okl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-open-diameter"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-open-group"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-openi-pl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-openmap"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-openmarket-fastcgi"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opennetcf-shared-source"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-openorb-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-openpbs-2.3"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-opensaml-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-openssl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-openvpn-as-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opera-eula-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opera-eula-eea-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opera-widget-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-opml-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opnl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-opnl-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-java-platform-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-java-platform-2017"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-javaee"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-javase-javafx-2012"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-javase-javafx-2013"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-bcl-jsse-1.0.3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-code-samples-bsd"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-commercial-db-11g2"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-devtools-vsnet-dev"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-entitlement-05-15"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-java-ee-sdk-2010"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-master-agreement"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-nftc-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-otn-javase-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-sql-developer"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-web-sites-tou"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oreilly-notice"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-osetpl-2.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-osf-1990"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-osgi-spec-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ossn-3.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oswego-concurrent"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-other-copyleft"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-other-permissive"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-dev-dist"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-dev-dist-2009"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-dev-dist-2014"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-dev-dist-2016"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-early-adopter-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-early-adopter-development"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-otn-standard-2014-09"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owal-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owf-cla-1.0-copyright"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owf-cla-1.0-copyright-patent"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owfa-1.0"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owfa-1.0-patent-only"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-owtchart"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-oxygen-xml-webhelp-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ozplb-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ozplb-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paint-net"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paolo-messina-2000"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paraview-1.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-passive-aggressive"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-patent-disclaimer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-hsieh-derivative"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-hsieh-exposition"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-mackerras"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-mackerras-binary"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-mackerras-new"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paul-mackerras-simplified"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paulo-soares"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-paypal-sdk-2013-2016"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pbl-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pcre"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pd-mit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pd-programming"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pdf-creator-pilot"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pdl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-perl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-peter-deutsch-document"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pfe-proprietary-notice"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pftijah-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-pftus-1.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-phil-bunce"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-philippe-de-muyter"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-philips-proprietary-notice2000"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-phorum-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-php-2.0.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pine"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pivotal-tou"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pixabay-content"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-planet-source-code"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pml-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pngsuite"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-politepix-pl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-defensive-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-free-trial-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-internal-use-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-perimeter-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-shield-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-polyform-strict-1.0.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-powervr-tools-software-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ppp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-proprietary"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-proprietary-license"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-prosperity-1.0.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-prosperity-2.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-prosperity-3.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-protobuf"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-psf-3.7.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-psytec-freesoft"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-public-domain"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-public-domain-disclaimer"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-purdue-bsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pybench"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pycrypto"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pygres-2.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-python-cwi"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qaplug"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qca-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qca-technology"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qlogic-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qlogic-microcode"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qpopper"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qt-commercial-1.1"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qti-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qualcomm-iso"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qualcomm-turing"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-quickfix-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-quicktime"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-quin-street"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-quirksmode"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-qwt-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-rackspace"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-radvd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ralf-corsepius"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ralink-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rar-winrar-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rcsl-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rcsl-3.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-realm-platform-extension-2017"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-red-hat-attribution"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-red-hat-bsd-simplified"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-red-hat-logos"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-red-hat-trademarks"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-redis-source-available-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-reportbug"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rh-eula"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-rh-eula-lgpl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ricebsd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-richard-black"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-riverbank-sip"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-robert-hubley"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rogue-wave"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-1990"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-cryptoki"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-demo"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-md2"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-md4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rsa-proprietary"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rtools-util"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rubyencoder-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rubyencoder-loader"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rute"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ryszard-szopa"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-saas-mit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-saf"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-safecopy-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-san-francisco-font"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sandeep"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sash"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sata"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sbia-b"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scancode-acknowledgment"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scanlogd-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scansoft-1.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scilab-en"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scilab-fr"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scintilla"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scola-en"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scola-fr"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scribbles"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-script-asylum"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-script-nikhilk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scrub"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-scsl-3.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-secret-labs-2011"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-see-license"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sencha-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sencha-commercial-3.17"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sencha-commercial-3.9"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-service-comp-arch"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sgi-cid-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sgi-glx-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sglib"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-shavlik-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-shital-shah"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-simpl-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-slf4j-2005"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-slf4j-2008"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-slysoft-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-smail-gpl"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-smartlabs-freeware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-snmp4j-smi"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-snprintf"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-softerra-ldap-browser-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-softfloat"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-softfloat-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-softsurfer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-solace-software-eula-2020"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-spark-jive"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sparky"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-speechworks-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-splunk-3pp-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-splunk-mint-tos-2018"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-splunk-sla"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-square-cla"
+  categories:
+  - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-squeak"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-srgb"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ssleay"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ssleay-windows"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-st-bsd-restricted"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-st-mcd-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stanford-mrouted"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-stanford-pvrg"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-statewizard"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-stax"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-stlport-2000"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stlport-4.5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stmicro-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stmicroelectronics-centrallabs"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stream-benchmark"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-stu-nicholls"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-11-06"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-11-07"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-11-08"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.2.x"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.4.2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-j2re-1.4.x"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-j2re-5.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-java-servlet-imp-2.1.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-javahelp"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-jimi-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-jre6"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-jsmq"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-opendmk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-openjdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-sdk-1.3"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-sdk-1.4.2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-sdk-5.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-sdk-6.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bcl-web-start"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-bsd-extra"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-communications-api"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-ejb-spec-2.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-ejb-spec-3.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-entitlement-03-15"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-entitlement-jaf"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-glassfish"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-iiop"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-java-transaction-api"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-java-web-services-dev-1.6"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-javamail"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-jsr-spec-04-2006"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-jta-spec-1.0.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-jta-spec-1.0.1b"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-no-high-risk-activities"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-project-x"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-prop-non-commercial"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-proprietary-jdk"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-rpc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-sdk-spec-1.1"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-sissl-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-source"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sun-ssscfr-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-sunpro"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sunsoft"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-supervisor"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sustainable-use-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-svndiff"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-swig"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-symphonysoft"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-synopsys-attribution"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-synopsys-mit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-synthesis-toolkit"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-takao-abe"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-takuya-ooura"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-taligent-jdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.2"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-community-sla-1.3"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-development"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tanuki-maintenance"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-teamdev-services"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tekhvc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-telerik-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tenable-nessus"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-term-readkey"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tested-software"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tex-live"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tfl"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tgppl-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-things-i-made-public-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-thomas-bandt"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-thor-pl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ti-broadband-apps"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ti-linux-firmware"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ti-restricted"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tiger-crypto"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tigra-calendar-3.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tigra-calendar-4.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tim-janik-2003"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-timestamp-picker"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tizen-sdk"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tpl-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-trademark-notice"
+  categories:
+  - "unstated-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-trca-odl-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-treeview-developer"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-treeview-distributor"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-triptracker"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-truecrypt-3.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-tsl-2018"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tsl-2020"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tso-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ttcl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ttf2pt1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ttyp0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tumbolia"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-twisted-snmp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-txl-10.5"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ubc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ubuntu-font-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unbuntu-font-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unicode"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unicode-data-software"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unicode-icu-58"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unicode-mappings"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unknown"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unknown-license-reference"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unknown-spdx"
+  categories:
+  - "unknown"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unpbook"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unpublished-source"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unrar"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-unsplash"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-uofu-rfpl"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-us-govt-public-domain"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-us-govt-unlimited-rights"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-usrobotics-permissive"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-utopia"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vbaccelerator"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vcalendar"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-verisign"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vhfpl-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-vic-metcalfe-pd"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vicomsoft-software"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-visual-idiot"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-visual-numerics"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vita-nuova-liberal"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-vitesse-prop"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vixie-cron"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vnc-viewer-ios"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-volatility-vsl-v1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-vpl-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-vpl-1.2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-vs10x-code-map"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-vuforia-2013-07-29"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-w3c-docs-19990405"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-w3c-docs-20021231"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-w3c-documentation"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-w3c-software-20021231"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-w3c-test-suite"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-warranty-disclaimer"
+  categories:
+  - "generic"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-waterfall-feed-parser"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-westhawk"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-whistle"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-whitecat"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wide-license"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wifi-alliance"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-william-alexander"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wince-50-shared-source"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-windriver-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wingo"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wink"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-winzip-eula"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-winzip-self-extractor"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wol"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wordnet"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wrox"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wrox-download"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ws-addressing-spec"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ws-policy-specification"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ws-trust-specification"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wtfnmfpl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wtfpl-1.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wthpl-1.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wxwidgets"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wxwindows-r-3.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-wxwindows-u-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-acer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-adobe"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-adobe-dec"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-bitstream"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-dec1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-dec2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-doc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-dsc"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-hanson"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-ibm"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-x11-lucent"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-lucent-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-oar"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-opengl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-quarterdeck"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-r75"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-realmode"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-sg"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-stanford"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-tektronix"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-x11r5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-xconsortium-veillard"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11r5-authors"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xceed-community-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xfree86-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xilinx-2016"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xming"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xmldb-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xxd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yahoo-browserplus-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yahoo-messenger-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yale-cas"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yensdesign"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yolo-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yolo-2.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zapatec-calendar"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zeusbench"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zhorn-stickies"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zipeg"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ziplist5-geocode-dup-addendum"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ziplist5-geocode-enterprise"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ziplist5-geocode-workstation"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zpl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zsh"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zuora-software"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-zveno-research"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Linux-OpenIB"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Linux-man-pages-copyleft"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "MIT"
   categories:
   - "permissive"
@@ -257,11 +6564,15 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "MIT-advertising"
+- id: "MIT-CMU"
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "MIT-CMU"
+- id: "MIT-Modern-Variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "MIT-advertising"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -273,6 +6584,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "MIT-open-group"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "MITNFA"
   categories:
   - "permissive"
@@ -281,14 +6596,22 @@ categorizations:
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "MPL-1.1"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "MPL-2.0"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "MPL-2.0-no-copyleft-exception"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "MS-PL"
   categories:
   - "permissive"
@@ -297,11 +6620,178 @@ categorizations:
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "MTLL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "MakeIndex"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "MirOS"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Motosoto"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "MulanPSL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "MulanPSL-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Multics"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Mup"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NAIST-2003"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NASA-1.3"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NBPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NCGL-UK-2.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "NCSA"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NGPL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NIST-PD"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "NIST-PD-fallback"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NLOD-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NLOD-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NLPL"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "NOSL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NPL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NPOSL-3.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "NRL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NTP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NTP-0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Naumen"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Net-SNMP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "NetCDF"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Newsletr"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Nokia"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Noweb"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "O-UDA-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OCCT-PL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OCLC-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "ODC-By-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "ODbL-1.0"
   categories:
   - "copyleft"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "OFL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OFL-1.0-RFN"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OFL-1.0-no-RFN"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -309,15 +6799,244 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "OFL-1.1-RFN"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OFL-1.1-no-RFN"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGC-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGDL-Taiwan-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGL-Canada-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGL-UK-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGL-UK-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGL-UK-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OGTSL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OLDAP-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OLDAP-1.2"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OLDAP-1.3"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OLDAP-1.4"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OLDAP-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.0.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.2.2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.3"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.6"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.7"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OLDAP-2.8"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OML"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OPUBL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OSET-PL-2.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OSL-1.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OSL-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OSL-2.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OSL-2.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "OSL-3.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "OpenSSL"
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "PSF"
+- id: "PDDL-1.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "PHP-3.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "PHP-3.01"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "PSF-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Parity-6.0.0"
   categories:
   - "copyleft"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Parity-7.0.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Plexus"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "PolyForm-Noncommercial-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "PolyForm-Small-Business-1.0.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "PostgreSQL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "Python-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "QPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Qhull"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "RHeCos-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "RPL-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "RPL-1.5"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "RPSL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "RSA-MD"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "RSCPL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Rdisc"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -325,19 +7044,218 @@ categorizations:
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "SAX-PD"
   categories:
   - "public-domain"
+  - "include-in-notice-file"
+- id: "SCEA"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SGI-B-1.0"
+  categories:
+  - "free-restricted"
+  - "include-in-notice-file"
+- id: "SGI-B-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SGI-B-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SHL-0.5"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SHL-0.51"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SISSL"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "SISSL-1.2"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "SMLNJ"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SMPPL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "SNIA"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "SPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "SSH-OpenSSH"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SSH-short"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SSPL-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "SWL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Saxpath"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SchemeReport"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Sendmail"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Sendmail-8.23"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "SimPL-2.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Sleepycat"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Spencer-86"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Spencer-94"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Spencer-99"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "SugarCRM-1.1.3"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "TAPR-OHL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "TCL"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "TCP-wrappers"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "TMate"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "TORQUE-1.1"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "TOSL"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "TU-Berlin-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "TU-Berlin-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "UCL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "UPL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Unicode-DFS-2015"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Unicode-DFS-2016"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Unicode-TOU"
+  categories:
+  - "proprietary-free"
   - "include-in-notice-file"
 - id: "Unlicense"
   categories:
   - "public-domain"
   - "include-in-notice-file"
+- id: "VOSTROM"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "VSL-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Vim"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "W3C"
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "W3C-19980720"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "W3C-20150513"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "WTFPL"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "Watcom-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "Wsuipa"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -345,19 +7263,164 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "X11-distribute-modifications-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "XFree86-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "XSkat"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Xerox"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Xnet"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "YPL-1.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "YPL-1.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "ZPL-1.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ZPL-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ZPL-2.1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Zed"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Zend-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "Zimbra-1.3"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "Zimbra-1.4"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "Zlib"
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "bzip2-1.0.5"
+- id: "blessing"
   categories:
-  - "permissive"
+  - "public-domain"
   - "include-in-notice-file"
 - id: "bzip2-1.0.6"
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "copyleft-next-0.3.0"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "copyleft-next-0.3.1"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "curl"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "diffmark"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "dvipdfm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "eGenix"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "etalab-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "gSOAP-1.3b"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "gnuplot"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "iMatix"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "libpng-2.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "libselinux-1.0"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "libtiff"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "mpich2"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "mplus"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "psfrag"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "psutils"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "wxWindows"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "xinetd"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "xpp"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "zlib-acknowledgement"
   categories:
   - "permissive"
   - "include-in-notice-file"

--- a/notifications/gradle/libs.versions.toml
+++ b/notifications/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "b9e8b63ace"
+ort = "e8c786d3bb"
 
 [libraries]
 ortNotifier = { module = "com.github.oss-review-toolkit.ort:notifier", version.ref = "ort" }

--- a/tools/curations/build.gradle.kts
+++ b/tools/curations/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.ossreviewtoolkit.tools.curations.GenerateAspNetCoreCurationsTask
 import org.ossreviewtoolkit.tools.curations.GenerateAzureSdkForNetCurationsTask
 import org.ossreviewtoolkit.tools.curations.GenerateDotNetRuntimeCurationsTask
+import org.ossreviewtoolkit.tools.curations.GenerateLicenseClassificationsTask
 import org.ossreviewtoolkit.tools.curations.VerifyPackageConfigurationsTask
 import org.ossreviewtoolkit.tools.curations.VerifyPackageCurationsTask
 
 tasks {
+    register<GenerateLicenseClassificationsTask>("generateLicenseClassifications")
     register<GenerateAspNetCoreCurationsTask>("generateAspNetCoreCurations")
     register<GenerateAzureSdkForNetCurationsTask>("generateAzureSdkForNetCurations")
     register<GenerateDotNetRuntimeCurationsTask>("generateDotNetRuntimeCurations")

--- a/tools/curations/buildSrc/src/main/kotlin/GenerateLicenseClassificationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/GenerateLicenseClassificationsTask.kt
@@ -1,0 +1,20 @@
+package org.ossreviewtoolkit.tools.curations
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class GenerateLicenseClassificationsTask : DefaultTask() {
+    init {
+        group = "generate license classifications"
+        description = "Generates 'license-classifications.yml' from ScanCode's license database available hosted at " +
+                "https://scancode-licensedb.aboutcode.org."
+    }
+
+    @TaskAction
+    fun generate() {
+        project.rootDir.resolve("../../license-classifications.yml").apply {
+            writeText(generateLicenseClassificationsYaml())
+            logger.quiet("Wrote license classifications to '$absolutePath'.")
+        }
+    }
+}

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -1,0 +1,189 @@
+package org.ossreviewtoolkit.tools.curations
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import kotlin.time.measureTime
+
+import org.gradle.api.logging.Logging
+import org.ossreviewtoolkit.model.licenses.LicenseCategorization
+import org.ossreviewtoolkit.model.licenses.LicenseCategory
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.yamlMapper
+import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
+
+private val INDEX_JSON_URL =  "https://scancode-licensedb.aboutcode.org/index.json"
+private val DISCLAIMER_TEXT = """
+License classification generated based on https://scancode-licensedb.aboutcode.org/.    
+    
+This ORT configuration file is provided as an example only. It
+demonstrates the general configuration capabilities of ORT and does not
+reflect any real-world configuration used by the ORT contributors, nor
+are they a recommendation on the configuration to use.
+
+Please consult your legal counsel about how ORT should be configured for your use cases.
+
+For detailed documentation on this file, see
+https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-license-classifications-yml.md.
+"""
+
+private val LOGGER = Logging.getLogger("ScanCodeLicenseDbClassifications")
+private val JSON_MAPPER = JsonMapper().apply {
+    KotlinModule.Builder()
+        .configure(KotlinFeature.NullIsSameAsDefault, true)
+        .build()
+        .let { registerModule(it) }
+
+    propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+}
+
+private data class License(
+    val licenseKey: String,
+    val spdxLicenseKey: String? = null,
+    val otherSpdxLicenseKeys: List<String> = emptyList(),
+    val isException: Boolean,
+    val isDeprecated: Boolean,
+    val category: String,
+    val json: String,
+    val yml: String,
+    val html: String,
+    val text: String
+)
+
+private data class LicenseDetails(
+    val key: String,
+    val shortName: String,
+    val name: String,
+    val category: String,
+    val owner: String,
+    val homepageUrl: String? = null,
+    val notes: String? = null,
+    val spdxLicenseKey: String? = null,
+    val minimumCoverage: Int? = null,
+    val standardNotice: String? = null,
+    val isDeprecated: Boolean = false,
+    val isException: Boolean = false,
+    val isGeneric: Boolean = false,
+    val isUnknown: Boolean = false,
+    val ignorableCopyrights: List<String> = emptyList(),
+    val ignorableHolders: List<String> = emptyList(),
+    val ignorableAuthors: List<String> = emptyList(),
+    val ignorableEmails: List<String> = emptyList(),
+    val ignorableUrls: List<String> = emptyList(),
+    val textUrls: List<String> = emptyList(),
+    val otherUrls: List<String> = emptyList(),
+    val faqUrl: String? = null,
+    val osiLicenseKey: String? = null,
+    val otherSpdxLicenseKeys: List<String> = emptyList(),
+    val osiUrl: String? = null,
+    val language: String? = null
+)
+
+private fun downloadLicenseIndex(): List<License> =
+    JSON_MAPPER.readValue<List<License>>(URL(INDEX_JSON_URL))
+
+private fun downloadLicenseDetails(license: License): LicenseDetails {
+    val url = INDEX_JSON_URL.substringBeforeLast("/") + "/${license.json}"
+    LOGGER.info("GET $url.")
+    return JSON_MAPPER.readValue<LicenseDetails>(URL(url))
+}
+
+@OptIn(kotlin.time.ExperimentalTime::class)
+private fun downloadLicenseDetailsBatched(
+    licenses: Collection<License>,
+    threadCount: Int = 60
+): Map<License, LicenseDetails> {
+    val queue = ConcurrentLinkedQueue(licenses)
+    val result = ConcurrentHashMap<License, LicenseDetails>()
+
+    val threads = List(threadCount) { _ ->
+        Thread {
+            var license = queue.poll()
+
+            while (license != null) {
+                result[license] = downloadLicenseDetails(license)
+                license = queue.poll()
+            }
+        }
+    }
+
+    val executionTime = measureTime {
+        threads.run {
+            forEach { it.start() }
+            forEach { it.join() }
+        }
+    }
+
+    LOGGER.quiet("Downloaded ${result.size} files in $executionTime on $threadCount threads.")
+
+    return result.toMap()
+}
+
+private fun LicenseDetails.getLicenseId(): SpdxSingleLicenseExpression {
+    val expression = spdxLicenseKey ?: otherSpdxLicenseKeys.firstOrNull() ?: "LicenseRef-scancode-${key}"
+    return SpdxSingleLicenseExpression.parse(expression)
+}
+
+private fun LicenseDetails.getCategories(): Set<String> {
+    // TODO: Check if the category "Unstated License" could additionally be used by below mapping to move
+    // license IDs which do no correspond to "normal" license to separate categories.
+    val mappedCategory = when {
+        isUnknown -> "unknown"
+        isGeneric -> "generic"
+        else -> category.replace(' ', '-').toLowerCase()
+    }
+
+    return setOfNotNull(
+        mappedCategory,
+        // Include all licenses into the notice file to ensure there is not under-reporting by default.
+        "include-in-notice-file",
+        // The FSF has stated that a source code offer is required for Copyleft (limited) licences, so
+        // include only these to not cause unnecessary effort by default.
+        "include-source-code-offer-in-notice-file".takeIf { mappedCategory in setOf("copyleft", "copyleft-limited") }
+    )
+}
+
+private fun getLicenseClassifications(licenseDetails: Collection<LicenseDetails>) =
+    LicenseClassifications(
+        categories = licenseDetails.flatMap { it.getCategories() }.distinct().map {
+            LicenseCategory(it)
+        }.sortedBy { it.name },
+        categorizations = licenseDetails.map {
+            LicenseCategorization(
+                id = it.getLicenseId(),
+                categories = it.getCategories()
+            )
+        }.sortedBy { it.id.toString() }
+    )
+
+/**
+ * Generate license classifications from ScanCode's license categories.
+ *
+ * The original categories are used except for 'unknown' and 'generic' licenses, which are assigned to a separate
+ * category.
+ */
+fun generateLicenseClassificationsYaml(): String {
+    val licenses = downloadLicenseIndex().filterNot {
+        it.isException || it.licenseKey == "x11-xconsortium_veillard"
+    }
+    val licenseDetails = downloadLicenseDetailsBatched(licenses).values
+    val licenseClassifications = getLicenseClassifications(licenseDetails)
+
+    licenseClassifications.run {
+        LOGGER.quiet(
+            "Generated a license classification with ${categorizations.size} license and ${categories.size} categories."
+        )
+    }
+
+    val yaml = yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(licenseClassifications)
+    val disclaimer = DISCLAIMER_TEXT.split('\n').map { "# $it".trim() }.joinToString("\n")
+
+    return "$disclaimer\n$yaml"
+}

--- a/tools/curations/gradle/libs.versions.toml
+++ b/tools/curations/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "b9e8b63ace"
+ort = "e8c786d3bb"
 
 [libraries]
 ortModel = { module = "com.github.oss-review-toolkit.ort:model", version.ref = "ort" }


### PR DESCRIPTION
Add a Gradle task which generates `license-classifications.yml` from ScanCode's license data hosted at `aboutcode.org` and make use of the generated file.

Fixes #59.

Note: As a follow up, policy rules will need to be extended to handle new license categories.
          For now, the newly added categories will still be flagged by the evaluator rule `UNHANDLED_LICENSE`.