### PR TITLE
Fix a couple of rule violations for the `mime-types` example scan

### DIFF
--- a/package-configurations/NPM/_/spdx-correct/3.1.0/vcs.yml
+++ b/package-configurations/NPM/_/spdx-correct/3.1.0/vcs.yml
@@ -1,0 +1,20 @@
+---
+id: "NPM::spdx-correct:3.1.0"
+vcs:
+  type: "Git"
+  url: "https://github.com/jslicense/spdx-correct.js.git"
+  revision: "6e556b4af7bee9899e7f16ae8f745719e5517e5d"
+path_excludes:
+- pattern: "package.json"
+  reason: "BUILD_TOOL_OF"
+- pattern: "test.js"
+  reason: "TEST_OF"
+- pattern: "README.md"
+  reason: "DOCUMENTATION_OF"
+license_finding_curations:
+- path: "index.js"
+  reason: "CODE"
+  concluded_license: "Apache-2.0"
+  comment: "The code contains listings of license identifiers which do not apply.\
+    \ The only license text is in the header of the file stating that it is licensed\
+    \ under 'Apache-2.0'."

--- a/package-configurations/NPM/_/spdx-exceptions/2.2.0/vcs.yml
+++ b/package-configurations/NPM/_/spdx-exceptions/2.2.0/vcs.yml
@@ -1,0 +1,15 @@
+---
+id: "NPM::spdx-exceptions:2.2.0"
+vcs:
+  type: "Git"
+  url: "https://github.com/kemitchell/spdx-exceptions.json.git"
+  revision: "c33d7b8f1966c486c8f831e0dd1c5af6f4deefbd"
+path_excludes:
+- pattern: "package.json"
+  reason: "BUILD_TOOL_OF"
+license_finding_curations:
+- path: "index.json"
+  concluded_license: "NONE"
+  reason: "INCORRECT"
+  comment: "The files do not contain any license text, just a large listing of SPDX\
+    \ license IDs causing false positives."

--- a/package-configurations/NPM/_/spdx-license-ids/3.0.5/vcs.yml
+++ b/package-configurations/NPM/_/spdx-license-ids/3.0.5/vcs.yml
@@ -1,0 +1,20 @@
+---
+id: "NPM::spdx-license-ids:3.0.5"
+vcs:
+  type: "Git"
+  url: "https://github.com/shinnn/spdx-license-ids.git"
+  revision: "2bc004aae6f30d625d3aad95eac09d9aaf1c97cc"
+path_excludes:
+- pattern: "package.json"
+  reason: "BUILD_TOOL_OF"
+license_finding_curations:
+- path: "Readme-md"
+  concluded_license: "CC0-1.0"
+  reason: "INCORRECT"
+  comment: "The file contains examples which in turn contain SPDX license IDs causing\
+    \ false positives. The license section says that it is licensed under 'CC0-1.0'."
+- path: "{index.json|deprecated.json}"
+  concluded_license: "NONE"
+  reason: "INCORRECT"
+  comment: "The files do not contain any license text, just a large listing of SPDX\
+    \ license IDs causing false positives."

--- a/package-configurations/NPM/_/v8-compile-cache/2.1.0/vcs.yml
+++ b/package-configurations/NPM/_/v8-compile-cache/2.1.0/vcs.yml
@@ -1,0 +1,11 @@
+---
+id: "NPM::v8-compile-cache:2.1.0"
+vcs:
+  type: "Git"
+  url: "https://github.com/zertosh/v8-compile-cache.git"
+  revision: "0b9eae0a5f61955f0001d8ebcf3f8410df42f4b6"
+path_excludes:
+- pattern: "bench/**"
+  reason: "TEST_OF"
+- pattern: "package.json"
+  reason: "BUILD_TOOL_OF"


### PR DESCRIPTION
Fix violations in 4 packages which cause a high amount of false positives, to reduce the amount of errors quite a bit.