### PR TITLE
evaluator-rules: Improve the disclaimer a bit

### DIFF
--- a/evaluator-rules/src/main/resources/evaluator.rules.kts
+++ b/evaluator-rules/src/main/resources/evaluator.rules.kts
@@ -17,13 +17,11 @@
  * License-Filename: LICENSE
  */
 
-/*******************************************************
- * Example OSS Review Toolkit (ORT) .rules.kts file    *
- *                                                     *
- * Note this file only contains example how to write   *
- * rules. It's recommended you consult your own legal  *
- * when writing your own rules.                        *
- *******************************************************/
+/******************************************************************************
+ * DISCLAIMER: This file only illustrates how to write evaluator rules, it is *
+ *             no recommendation in any way. It is recommended to consult     *
+ *             your own legal counsel(s) for setting up your evaluator rules. *
+ ******************************************************************************/
 
 /**
  * Variables defining the organization using ORT.


### PR DESCRIPTION
Drop the copy pasted mention of "ORT examples", make the disclaimer a bit more prominent and avoid using the term example overall while still making clear that no legal recommendation is made. While at it wrap it at 80 chars.

