### PR TITLE
evaluator.rules: Add 'free-restricted' to handled licenses

### DIFF
--- a/evaluator-rules/src/main/resources/evaluator.rules.kts
+++ b/evaluator-rules/src/main/resources/evaluator.rules.kts
@@ -55,6 +55,7 @@ val publicDomainLicenses = getLicensesForCategory("public-domain")
 val handledLicenses = listOf(
     copyleftLicenses,
     copyleftLimitedLicenses,
+    freeRestrictedLicenses,
     permissiveLicenses,
     proprietaryFreeLicenses,
     publicDomainLicenses


### PR DESCRIPTION
This is a fix-up for 87c2049e329148390c524b82ddea460cf0cb4375.

Context: #66.