### PR TITLE
evaluator.rules: Add a missing `-isExcluded()`

### DIFF
--- a/evaluator-rules/src/main/resources/evaluator.rules.kts
+++ b/evaluator-rules/src/main/resources/evaluator.rules.kts
@@ -1444,6 +1444,7 @@ fun RuleSet.unkownInDependencyRule() = packageRule("UNKNOWN_IN_DEPENDENCY") {
         require {
             +isUnknown()
             -isIgnored()
+            -isExcluded()
         }
 
         error(


### PR DESCRIPTION
This is a fix-up for 3c394bc8fdc16af63d867fc6bcc92a002a1d40ac.

Context: #66.