### PR TITLE
Use the new copyright statement in all files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+The ORT Project <https://oss-review-toolkit.org>
+
+Copyright (C) 2019-2022 HERE Europe B.V.
+Copyright (C) 2021-2022 Bosch.IO GmbH
+Copyright (C) 2022 EPAM Systems, Inc.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ This repository is currently in incubation and not yet ready for contributions.
 
 # License
 
-Copyright (C) 2019-2022 HERE Europe B.V.
-Copyright (C) 2022 Bosch.IO GmbH
+Copyright (C) 2019-2022 [The ORT Project Authors](./NOTICE).
 
 See the [LICENSE](./LICENSE) file in the root of this project for license details.
 

--- a/evaluator-rules/build.gradle.kts
+++ b/evaluator-rules/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Bosch.IO GmbH
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/evaluator-rules/src/main/resources/evaluator.rules.kts
+++ b/evaluator-rules/src/main/resources/evaluator.rules.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 HERE Europe B.V.
+ * Copyright (C) 2019 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/how-to-fix-text-provider.kts
+++ b/how-to-fix-text-provider.kts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
 object : HowToFixTextProvider {
     override fun getHowToFixText(issue: OrtIssue): String? = null
 }

--- a/notice/by-package.ftl
+++ b/notice/by-package.ftl
@@ -1,6 +1,5 @@
 [#--
-    Copyright (C) 2020 HERE Europe B.V.
-    Copyright (C) 2021 Bosch.IO GmbH
+    Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/notice/summary.ftl
+++ b/notice/summary.ftl
@@ -1,6 +1,5 @@
 [#--
-    Copyright (C) 2020 HERE Europe B.V.
-    Copyright (C) 2021 Bosch.IO GmbH
+    Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Bosch.IO GmbH
+ * Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/notifications/src/main/resources/example.notifications.kts
+++ b/notifications/src/main/resources/example.notifications.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Bosch.IO GmbH
+ * Copyright (C) 2021 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As agreed upon in [1].

[1]: https://github.com/oss-review-toolkit/ort-governance/issues/6
