### PR TITLE
Gradle: Update ORT to 7aa61bf96b

### DIFF
--- a/evaluator-rules/gradle/libs.versions.toml
+++ b/evaluator-rules/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "e8c786d3bb"
+ort = "7aa61bf96b"
 
 [libraries]
 ortEvaluator = { module = "com.github.oss-review-toolkit.ort:evaluator", version.ref = "ort" }

--- a/notifications/gradle/libs.versions.toml
+++ b/notifications/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "e8c786d3bb"
+ort = "7aa61bf96b"
 
 [libraries]
 ortNotifier = { module = "com.github.oss-review-toolkit.ort:notifier", version.ref = "ort" }

--- a/tools/curations/gradle/libs.versions.toml
+++ b/tools/curations/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "e8c786d3bb"
+ort = "7aa61bf96b"
 
 [libraries]
 ortModel = { module = "com.github.oss-review-toolkit.ort:model", version.ref = "ort" }


### PR DESCRIPTION
This fixes the security vulnerability CVE-2022-42003, see: [1]. Full changes can be found here [2].

[1]: https://nvd.nist.gov/vuln/detail/CVE-2022-42003
[2]: https://github.com/oss-review-toolkit/ort/compare/e8c786d3bb...7aa61bf96b

