### PR TITLE
deps(Gradle): Upgrade ORT to version e50456588d

### DIFF
--- a/evaluator-rules/gradle/libs.versions.toml
+++ b/evaluator-rules/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "7aa61bf96b"
+ort = "e50456588d"
 
 [libraries]
 ortEvaluator = { module = "com.github.oss-review-toolkit.ort:evaluator", version.ref = "ort" }

--- a/notifications/gradle/libs.versions.toml
+++ b/notifications/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "7aa61bf96b"
+ort = "e50456588d"
 
 [libraries]
 ortNotifier = { module = "com.github.oss-review-toolkit.ort:notifier", version.ref = "ort" }

--- a/tools/curations/buildSrc/build.gradle.kts
+++ b/tools/curations/buildSrc/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     // Leave out the versions so that the same versions as in ORT are used.
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.squareup.okhttp3:okhttp")
-    implementation("com.vdurmont:semver4j")
+    implementation("org.semver4j:semver4j")
 }

--- a/tools/curations/buildSrc/src/main/kotlin/Utils.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/Utils.kt
@@ -1,6 +1,5 @@
 package org.ossreviewtoolkit.tools.curations
 
-import com.vdurmont.semver4j.Semver
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logging
 import org.ossreviewtoolkit.model.Identifier
@@ -9,6 +8,8 @@ import org.ossreviewtoolkit.model.PackageCurationData
 import org.ossreviewtoolkit.model.VcsInfoCurationData
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.utils.common.encodeOr
+import org.semver4j.Semver
+
 import java.io.File
 
 private val logger = Logging.getLogger("utils")
@@ -27,7 +28,7 @@ fun List<PathCurationData>.toPathCurations(): List<PackageCuration> {
     var lastPath = ""
 
     // Group subsequent versions which belong to the same path.
-    val grouped = sortedBy { Semver(it.tag.removePrefix("v")) }
+    val grouped = sortedBy { Semver.coerce(it.tag.removePrefix("v")) }
         .fold(mutableListOf<MutableList<PathCurationData>>()) { acc, cur ->
             if (cur.path != lastPath) {
                 acc.add(mutableListOf())

--- a/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
@@ -44,13 +44,13 @@ open class VerifyPackageCurationsTask : DefaultTask() {
                                 "'${curation.id.toCoordinates()}' in file '$relativePath' does not have a package name."
                     }
 
-                    if (curation.id.version.isNotBlank()) {
+                    val version = curation.id.version
+                    if (version.isNotBlank()) {
                         runCatching {
-                            Requirement.buildIvy(curation.id.version)
+                            Requirement.buildIvy(version)
                         }.onFailure {
-                            issues += "The version '${curation.id.version}' in file '$relativePath' is not a valid " +
-                                    "Ivy version range. See: " +
-                                    "https://ant.apache.org/ivy/history/2.5.0/settings/version-matchers.html"
+                            issues += "The version '$version' in file '$relativePath' is not a valid Ivy version " +
+                            "range. See: https://ant.apache.org/ivy/history/2.5.0/settings/version-matchers.html"
                         }
                     }
 

--- a/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
@@ -48,7 +48,7 @@ open class VerifyPackageCurationsTask : DefaultTask() {
                         runCatching {
                             Requirement.buildIvy(curation.id.version)
                         }.onFailure {
-                            issues += "The version '${curation.id.version}' in file '$relativePath 'is not a valid " +
+                            issues += "The version '${curation.id.version}' in file '$relativePath' is not a valid " +
                                     "Ivy version range. See: " +
                                     "https://ant.apache.org/ivy/history/2.5.0/settings/version-matchers.html"
                         }

--- a/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/VerifyPackageCurationsTask.kt
@@ -49,8 +49,9 @@ open class VerifyPackageCurationsTask : DefaultTask() {
                     if (version.isNotBlank() && version.hasVersionRangeIndicators()) {
                         val range = RangesListFactory.create(version)
                         if (range.get().size == 0) {
-                            issues += "The version '${version}' in file '$relativePath' contains version range " +
-                                    "indicators, but cannot be parsed to a valid version range."
+                            issues += "The version of package '${curation.id.toCoordinates()}' in file " +
+                                    "'$relativePath' contains version range indicators, but cannot be parsed to a " +
+                                    "valid version range."
                         }
                     }
 

--- a/tools/curations/gradle/libs.versions.toml
+++ b/tools/curations/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ort = "7aa61bf96b"
+ort = "e50456588d"
 
 [libraries]
 ortModel = { module = "com.github.oss-review-toolkit.ort:model", version.ref = "ort" }


### PR DESCRIPTION
A preceeding change renamed the notice template files, which was done to align with ORT's recent refactoring of the
`PlainTextTemplateReporter`, formerly called `NoticeTemplateReporter`.

Upgrade ORT to have this `PlainTextTemplateReporter` available.

