### PR TITLE
Align license classification generation with recent ScanCode `licensedb` changes

### DIFF
--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -44,22 +44,22 @@ private val JSON_MAPPER = JsonMapper().apply {
     propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
 }
 
-private val CONTRIBUTOR_LICENSE_AGREEMENT_IDS = listOf(
-    "LicenseRef-scancode-cncf-corporate-cla-1.0",
-    "LicenseRef-scancode-cncf-individual-cla-1.0",
-    "LicenseRef-scancode-google-cla",
-    "LicenseRef-scancode-google-corporate-cla",
-    "LicenseRef-scancode-jetty-ccla-1.1",
-    "LicenseRef-scancode-ms-cla",
-    "LicenseRef-scancode-newton-king-cla",
-    "LicenseRef-scancode-owf-cla-1.0-copyright",
-    "LicenseRef-scancode-owf-cla-1.0-copyright-patent",
-    "LicenseRef-scancode-square-cla"
-).map { SpdxSingleLicenseExpression.parse(it) }.toSet()
-
 private const val CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT = "contributor-license-agreement"
 private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_UNKNOWN = "unknown"
+
+private val OVERRIDE_LICENSE_CATEGORIES = mapOf(
+    "LicenseRef-scancode-cncf-corporate-cla-1.0" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-cncf-individual-cla-1.0" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-google-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-google-corporate-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-jetty-ccla-1.1" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-ms-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-newton-king-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-owf-cla-1.0-copyright" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-owf-cla-1.0-copyright-patent" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
+    "LicenseRef-scancode-square-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT
+).mapKeys { (license, _) -> SpdxSingleLicenseExpression.parse(license) }
 
 private data class License(
     val licenseKey: String,
@@ -150,10 +150,11 @@ private fun LicenseDetails.getLicenseId(): SpdxSingleLicenseExpression {
 }
 
 private fun LicenseDetails.getCategories(): Set<String> {
+    val overrideLicenseCategory = OVERRIDE_LICENSE_CATEGORIES[getLicenseId()]
     val mappedCategory = when {
         isUnknown -> CATEGORY_UNKNOWN
         isGeneric -> CATEGORY_GENERIC
-        getLicenseId() in CONTRIBUTOR_LICENSE_AGREEMENT_IDS -> CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT
+        overrideLicenseCategory != null -> overrideLicenseCategory
         else -> category.replace(' ', '-').lowercase()
     }
 

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -44,7 +44,7 @@ private val JSON_MAPPER = JsonMapper().apply {
     propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
 }
 
-private const val CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT = "contributor-license-agreement"
+private const val CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT = "cla"
 private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_UNKNOWN = "unknown"
 

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -44,21 +44,21 @@ private val JSON_MAPPER = JsonMapper().apply {
     propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
 }
 
-private const val CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT = "cla"
+private const val CATEGORY_CLA = "cla"
 private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_UNKNOWN = "unknown"
 
 private val OVERRIDE_LICENSE_CATEGORIES = mapOf(
-    "LicenseRef-scancode-cncf-corporate-cla-1.0" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-cncf-individual-cla-1.0" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-google-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-google-corporate-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-jetty-ccla-1.1" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-ms-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-newton-king-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-owf-cla-1.0-copyright" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-owf-cla-1.0-copyright-patent" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT,
-    "LicenseRef-scancode-square-cla" to CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT
+    "LicenseRef-scancode-cncf-corporate-cla-1.0" to CATEGORY_CLA,
+    "LicenseRef-scancode-cncf-individual-cla-1.0" to CATEGORY_CLA,
+    "LicenseRef-scancode-google-cla" to CATEGORY_CLA,
+    "LicenseRef-scancode-google-corporate-cla" to CATEGORY_CLA,
+    "LicenseRef-scancode-jetty-ccla-1.1" to CATEGORY_CLA,
+    "LicenseRef-scancode-ms-cla" to CATEGORY_CLA,
+    "LicenseRef-scancode-newton-king-cla" to CATEGORY_CLA,
+    "LicenseRef-scancode-owf-cla-1.0-copyright" to CATEGORY_CLA,
+    "LicenseRef-scancode-owf-cla-1.0-copyright-patent" to CATEGORY_CLA,
+    "LicenseRef-scancode-square-cla" to CATEGORY_CLA
 ).mapKeys { (license, _) -> SpdxSingleLicenseExpression.parse(license) }
 
 private data class License(
@@ -162,7 +162,7 @@ private fun LicenseDetails.getCategories(): Set<String> {
         mappedCategory,
         // Include all licenses into the notice file to ensure there is no under-reporting by default.
         "include-in-notice-file".takeUnless {
-            mappedCategory in setOf(CATEGORY_UNKNOWN, CATEGORY_GENERIC, CATEGORY_CONTRIBUTOR_LICENSE_AGREEMENT)
+            mappedCategory in setOf(CATEGORY_UNKNOWN, CATEGORY_GENERIC, CATEGORY_CLA)
         },
         // The FSF has stated that a source code offer is required for Copyleft (limited) licences, so
         // include only these to not cause unnecessary effort by default.

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -49,16 +49,7 @@ private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_UNKNOWN = "unknown"
 
 private val OVERRIDE_LICENSE_CATEGORIES = mapOf(
-    "LicenseRef-scancode-cncf-corporate-cla-1.0" to CATEGORY_CLA,
-    "LicenseRef-scancode-cncf-individual-cla-1.0" to CATEGORY_CLA,
-    "LicenseRef-scancode-google-cla" to CATEGORY_CLA,
-    "LicenseRef-scancode-google-corporate-cla" to CATEGORY_CLA,
-    "LicenseRef-scancode-jetty-ccla-1.1" to CATEGORY_CLA,
-    "LicenseRef-scancode-ms-cla" to CATEGORY_CLA,
-    "LicenseRef-scancode-newton-king-cla" to CATEGORY_CLA,
-    "LicenseRef-scancode-owf-cla-1.0-copyright" to CATEGORY_CLA,
-    "LicenseRef-scancode-owf-cla-1.0-copyright-patent" to CATEGORY_CLA,
-    "LicenseRef-scancode-square-cla" to CATEGORY_CLA
+    "LicenseRef-scancode-ms-cla" to CATEGORY_CLA
 ).mapKeys { (license, _) -> SpdxSingleLicenseExpression.parse(license) }
 
 private data class License(

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -19,8 +19,8 @@ import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.yamlMapper
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
-private val INDEX_JSON_URL =  "https://scancode-licensedb.aboutcode.org/index.json"
-private val DISCLAIMER_TEXT = """
+private const val INDEX_JSON_URL =  "https://scancode-licensedb.aboutcode.org/index.json"
+private const val DISCLAIMER_TEXT = """
 License classification generated based on https://scancode-licensedb.aboutcode.org/.    
     
 This ORT configuration file is provided as an example only. It

--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -49,6 +49,7 @@ private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_UNKNOWN = "unknown"
 
 private val OVERRIDE_LICENSE_CATEGORIES = mapOf(
+    // https://github.com/nexB/scancode-toolkit/issues/3317.
     "LicenseRef-scancode-ms-cla" to CATEGORY_CLA
 ).mapKeys { (license, _) -> SpdxSingleLicenseExpression.parse(license) }
 


### PR DESCRIPTION
See individual commits.

This is part of #107 .

Note: The regeneration of `license-classifications.yml` needs to be deferred until https://github.com/nexB/scancode-licensedb/issues/35 is fixed and will be done in a separate PR.