### PR TITLE
fix(tools/curations): Make `LicenseDetails.text` nullable

### DIFF
--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -70,7 +70,7 @@ private data class LicenseDetails(
     val key: String,
     val shortName: String,
     val name: String,
-    val text: String,
+    val text: String? = null,
     val category: String,
     val owner: String,
     val homepageUrl: String? = null,


### PR DESCRIPTION
This is a fix-up for 4f1e2de.
