### PR TITLE
package-curations: Scan source artifacts for some `andriodx` and `kotlin` libs

### DIFF
--- a/curations/Maven/androidx.hilt/hilt-common.yml
+++ b/curations/Maven/androidx.hilt/hilt-common.yml
@@ -1,0 +1,6 @@
+- id: "Maven:androidx.hilt:hilt-common:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact, because figuring out the relevant files in the VCS is
+      complex.
+    source_code_origins: [ARTIFACT]

--- a/curations/Maven/androidx.interpolator/interpolator.yml
+++ b/curations/Maven/androidx.interpolator/interpolator.yml
@@ -1,0 +1,6 @@
+- id: "Maven:androidx.interpolator:interpolator:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact, because figuring out the relevant files in the VCS is
+      complex.
+    source_code_origins: [ARTIFACT]

--- a/curations/Maven/androidx.legacy/legacy-support-core-utils.yml
+++ b/curations/Maven/androidx.legacy/legacy-support-core-utils.yml
@@ -1,0 +1,6 @@
+- id: "Maven:androidx.legacy:legacy-support-core-utils:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact, because figuring out the relevant files in the VCS is
+      complex.
+    source_code_origins: [ARTIFACT]

--- a/curations/Maven/androidx.swiperefreshlayout/swiperefreshlayout.yml
+++ b/curations/Maven/androidx.swiperefreshlayout/swiperefreshlayout.yml
@@ -1,0 +1,6 @@
+- id: "Maven:androidx.swiperefreshlayout:swiperefreshlayout:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact, because figuring out the relevant files in the VCS is
+      complex.
+    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-android-extensions-runtime:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-annotation-processing-gradle.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-annotation-processing-gradle.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-annotation-processing-gradle:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-compiler-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-compiler-embeddable.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-daemon-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-daemon-embeddable.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-daemon-embeddable:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-klib-commonizer-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-klib-commonizer-embeddable.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-parcelize-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-parcelize-runtime.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-parcelize-runtime:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-reflect.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-reflect.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-reflect:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-script-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-script-runtime.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-common.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-common.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-jdk7:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-jdk8:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:"
+  curations:
+    comment: |
+      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
+    source_code_origins: [ ARTIFACT ]


### PR DESCRIPTION
For these artifacts it's better to scan the source artifact, as VCS provenance would need to be figured out manually which is hard in this case.

See individual commits.