### PR TITLE
fix(tool/curations): Drop an obsolete category override entry

### DIFF
--- a/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
+++ b/tools/curations/buildSrc/src/main/kotlin/ScanCodeLicenseDbClassifications.kt
@@ -51,9 +51,8 @@ private const val CATEGORY_GENERIC = "generic"
 private const val CATEGORY_PERMISSIVE = "permissive"
 private const val CATEGORY_UNKNOWN = "unknown"
 
-private val OVERRIDE_LICENSE_CATEGORIES = mapOf(
-    // https://github.com/nexB/scancode-toolkit/issues/3317.
-    "LicenseRef-scancode-ms-cla" to CATEGORY_CLA
+private val OVERRIDE_LICENSE_CATEGORIES = mapOf<String, String>(
+    // To override a category of a license add an entry like: "LicenseRef-scancode-ms-cla" to CATEGORY_CLA.
 ).mapKeys { (license, _) -> SpdxSingleLicenseExpression.parse(license) }
 
 // ScanCode does not provide categories for pairs of licenses and their belonging exceptions. So, hard-code some:


### PR DESCRIPTION
The issue has been fixed upstream and the update has been published, see https://scancode-licensedb.aboutcode.org/ms-cla.json.

Keep the mechanism to make it easy to override categories in the future. Also there may arise need to make the override categories configurable in the future which means there is likely need for this mechanism.
