### PR TITLE
feat(curations): Add VCS path curation for kotlin-test-js-runner

### DIFF
--- a/curations/Maven/org.jetbrains.kotlin/kotlin-test-js-runner.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-test-js-runner.yml
@@ -1,0 +1,5 @@
+- id: "Maven:org.jetbrains.kotlin:kotlin-test-js-runner:[1.4.0,)"
+  curations:
+    comment: "Set the VCS path of the module inside the multi-module repository."
+    vcs:
+      path: "libraries/tools/kotlin-test-js-runner"


### PR DESCRIPTION
See [1] for the start of the range.

[1]: https://github.com/JetBrains/kotlin/tree/1.4.0/libraries/tools/kotlin-test-js-runner

