### PR TITLE
chore: Change repo config and curation to warning

### DIFF
--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1369,7 +1369,7 @@ fun RuleSet.noLicenseInDependencyRule() = dependencyRule("NO_LICENSE_IN_DEPENDEN
 
 fun RuleSet.packageConfigurationInOrtYmlRule() = ortResultRule("PACKAGE_CONFIGURATION_IN_ORT_YML") {
     if (ortResult.repository.config.packageConfigurations.isNotEmpty()) {
-        error(
+        warning(
             "The use of package configurations is not allowed in the *.ort.yml file.",
             "Please use a global package configuration in the $ortConfigVcsMdLink."
         )
@@ -1378,7 +1378,7 @@ fun RuleSet.packageConfigurationInOrtYmlRule() = ortResultRule("PACKAGE_CONFIGUR
 
 fun RuleSet.packageCurationInOrtYmlRule() = ortResultRule("PACKAGE_CURATION_IN_ORT_YML") {
     if (ortResult.repository.config.curations.packages.isNotEmpty()) {
-        error(
+        warning(
             "The use of package curations is not allowed in the *.ort.yml file.",
             "Please use a global package curation in the $ortConfigVcsMdLink."
         )


### PR DESCRIPTION
A repository configuration or curation within an `.ort.yml` file may be purposeful. This declares a `WARNING` instead of `ERROR` for the evaluator.

Resolves oss-review-toolkit/ort#7753

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
