### PR TITLE
chore: Extend the "listenablefuture" curation to version 1.0

### DIFF
--- a/curations/Maven/com.google.guava/listenablefuture.yml
+++ b/curations/Maven/com.google.guava/listenablefuture.yml
@@ -1,3 +1,8 @@
+- id: "Maven:com.google.guava:listenablefuture:1.0"
+  curations:
+    comment: |
+      This library is empty as its version string suggests.
+    is_metadata_only: true
 - id: "Maven:com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava"
   curations:
     comment: |


### PR DESCRIPTION
Also version 1.0 is only "an empty artifact that Guava depends on to signal that it is providing ListenableFuture", "if users want only ListenableFuture, they depend on listenablefuture-1.0", see [1].

[1]: https://mvnrepository.com/artifact/com.google.guava/listenablefuture