### PR TITLE
chore: Update PyPI::packaging curation to version 23.2

### DIFF
--- a/curations/PyPI/_/packaging.yml
+++ b/curations/PyPI/_/packaging.yml
@@ -1,4 +1,4 @@
-- id: "PyPI::packaging:(,22.0["
+- id: "PyPI::packaging:(,23.2["
   curations:
     comment: |
       The library is licensed under BSD-2-Clause, see:


### PR DESCRIPTION
There has been no change on LICENSES for `PyPI::packaging`, which allows us to just increase the version to the current latest number, 23.2.