### PR TITLE
chore: Extend the version range of the existing `netty-all` curation

### DIFF
--- a/curations/Maven/io.netty/netty-all.yml
+++ b/curations/Maven/io.netty/netty-all.yml
@@ -1,7 +1,7 @@
 # Netty uses version with 'x.x.x.FINAL' which is interpreted as a pre-release version by Semver4j. The actual version
-# range for this curation is '[4.1.69.Final,4.1.79.Final]', which isn't interpreted as a valid version range by
+# range for this curation is '[4.1.69.Final,4.1.101.Final]', which isn't interpreted as a valid version range by
 # Semver4j. Therefore using a version range without the '.Final'.
-- id: "Maven:io.netty:netty-all:]4.1.68,4.1.79]"
+- id: "Maven:io.netty:netty-all:]4.1.68,4.1.101]"
   curations:
     comment: |
       The JAR files of these netty-all versions do not contain any classes files nor do they distribute any


### PR DESCRIPTION
The same applies to patch-level version 101, and mostly likely to all versions in between from 79.