### PR TITLE
fix(antlr): Map "BSD License" to `ANTLR-PD` for version 2.7.7

### DIFF
--- a/curations/Maven/antlr/antlr.yml
+++ b/curations/Maven/antlr/antlr.yml
@@ -21,3 +21,10 @@
       hash:
         value: "802655c343cc7806aaf1ec2177a0e663ff209de1"
         algorithm: "SHA1"
+- id: "Maven:antlr:antlr:2.7.7"
+  curations:
+    comment: |
+      Version 2.7.7 declares "BSD License" in its POM, which is wrong when looking at the `LICENSE.txt` contained in the
+      source artifact. Instead, it is the ANTLR-specific Public Domain license.
+    declared_license_mapping:
+      BSD License: "ANTLR-PD"


### PR DESCRIPTION
Version 2.7.7 declares "BSD License" in its POM [1], which is wrong when looking at the `LICENSE.txt` contained in the source artifact. Instead, it is the ANTLR-specific Public Domain license, see [2]

[1]: https://repo1.maven.org/maven2/antlr/antlr/2.7.7/antlr-2.7.7.pom
[2]: https://spdx.org/licenses/ANTLR-PD.html