### PR TITLE
fix(evaluator.rules): Limit "no license in dependency" rule to pkgs

### DIFF
--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1356,8 +1356,9 @@ fun RuleSet.missingTestsRule() = projectSourceRule("MISSING_TESTS") {
 
 fun RuleSet.noLicenseInDependencyRule() = dependencyRule("NO_LICENSE_IN_DEPENDENCY") {
     require {
-        -hasLicense()
+        -isProject()
         -isExcluded()
+        -hasLicense()
     }
 
     error(


### PR DESCRIPTION
The `-isProject()` condition was missing by accident.
