### PR TITLE
feat(curations): Set VCS info for the Maven `asm` library

### DIFF
--- a/curations/Maven/asm/asm.yml
+++ b/curations/Maven/asm/asm.yml
@@ -1,0 +1,7 @@
+- id: "Maven:asm:asm"
+  curations:
+    comment: |-
+      No SCM tag specified in the POM: https://repo1.maven.org/maven2/asm/asm/3.3.1/asm-3.3.1.pom
+    vcs:
+      type: "Git"
+      url: "https://gitlab.ow2.org/asm/asm.git"

--- a/curations/Maven/org.ow2.asm/asm.yml
+++ b/curations/Maven/org.ow2.asm/asm.yml
@@ -1,0 +1,7 @@
+- id: "Maven:org.ow2.asm:asm:(,6.0]"
+  curations:
+    comment: |-
+      No SCM tag specified in the POM: https://repo1.maven.org/maven2/org/ow2/asm/asm/6.0/asm-6.0.pom
+    vcs:
+      type: "Git"
+      url: "https://gitlab.ow2.org/asm/asm.git"


### PR DESCRIPTION
Note that never versions are available under the `org.ow2.asm` group, but still lack the SCM tag up to (and including) version 6.0.