### PR TITLE
perf(evaluator.rules): Consistently prefer package- over dependency rule

### DIFF
--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1109,7 +1109,7 @@ fun RuleSet.commercialInDependencyRule() = packageRule("COMMERCIAL_IN_DEPENDENCY
     }
 }
 
-fun RuleSet.copyleftInDependencyRule() = dependencyRule("COPYLEFT_IN_DEPENDENCY") {
+fun RuleSet.copyleftInDependencyRule() = packageRule("COPYLEFT_IN_DEPENDENCY") {
     require {
         -isProject()
         -isExcluded()
@@ -1354,7 +1354,7 @@ fun RuleSet.missingTestsRule() = projectSourceRule("MISSING_TESTS") {
     )
 }
 
-fun RuleSet.noLicenseInDependencyRule() = dependencyRule("NO_LICENSE_IN_DEPENDENCY") {
+fun RuleSet.noLicenseInDependencyRule() = packageRule("NO_LICENSE_IN_DEPENDENCY") {
     require {
         -isProject()
         -isExcluded()


### PR DESCRIPTION
For dependency trees made up of large amounts of package references relative to the amount of packages, `packageRule()` executes much faster compared to `dependencyRule()`. So, use `packageRule()` where possible to speed up the execution. For example, projects with large amounts of scopes, typical for Gradle based Android projects, can be evaluated faster.

