### PR TITLE
curations: Set source code origins for all `org.jetbrains.kotlin` libs

### DIFF
--- a/curations/Maven/org.jetbrains.kotlin/_.yml
+++ b/curations/Maven/org.jetbrains.kotlin/_.yml
@@ -1,4 +1,4 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib:"
+- id: "Maven:org.jetbrains.kotlin"
   curations:
     comment: |
       Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-android-extensions-runtime:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-annotation-processing-gradle.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-annotation-processing-gradle.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-annotation-processing-gradle:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-compiler-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-compiler-embeddable.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-compiler-embeddable:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-daemon-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-daemon-embeddable.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-daemon-embeddable:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-klib-commonizer-embeddable.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-klib-commonizer-embeddable.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-parcelize-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-parcelize-runtime.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-parcelize-runtime:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-reflect.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-reflect.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-reflect:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-script-runtime.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-script-runtime.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-script-runtime:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-common.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-common.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-common:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-jdk7:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]

--- a/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yml
+++ b/curations/Maven/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yml
@@ -1,5 +1,0 @@
-- id: "Maven:org.jetbrains.kotlin:kotlin-stdlib-jdk8:"
-  curations:
-    comment: |
-      Enforce scanning the source artifact because figuring out the relevant files in the VCS is complex.
-    source_code_origins: [ARTIFACT]


### PR DESCRIPTION
The rationale applies to all libraries in that namespace. So, apply the curation to the whole namespace.
