### PR TITLE
feat(package-configurations): Add some path excludes for commons-compress

### DIFF
--- a/package-configurations/Maven/org.apache.commons/commons-compress/1.26.2/vcs.yml
+++ b/package-configurations/Maven/org.apache.commons/commons-compress/1.26.2/vcs.yml
@@ -1,0 +1,9 @@
+---
+id: "Maven:org.apache.commons:commons-compress:1.26.2"
+vcs:
+  type: "Git"
+  url: "https://gitbox.apache.org/repos/asf/commons-compress.git"
+  revision: "95727006cac0892c654951c4e7f1db142462f22a"
+path_excludes:
+- pattern: "src/test/**"
+  reason: "TEST_OF"

--- a/package-configurations/Maven/org.apache.commons/commons-compress/1.26.2/vcs.yml
+++ b/package-configurations/Maven/org.apache.commons/commons-compress/1.26.2/vcs.yml
@@ -5,5 +5,30 @@ vcs:
   url: "https://gitbox.apache.org/repos/asf/commons-compress.git"
   revision: "95727006cac0892c654951c4e7f1db142462f22a"
 path_excludes:
+- pattern: ".github/**"
+  reason: "BUILD_TOOL_OF"
+- pattern: "CODE_OF_CONDUCT.md"
+  reason: "DOCUMENTATION_OF"
+- pattern: "CONTRIBUTING.md"
+  reason: "DOCUMENTATION_OF"
+- pattern: "SECURITY.md"
+  reason: "DOCUMENTATION_OF"
+- pattern: "src/changes/**"
+  reason: "DOCUMENTATION_OF"
+- pattern: "src/main/java/org/apache/commons/compress/archivers/examples/**"
+  reason: "EXAMPLE_OF"
+- pattern: "src/site/**"
+  reason: "DOCUMENTATION_OF"
 - pattern: "src/test/**"
   reason: "TEST_OF"
+license_finding_curations:
+- path: "src/main/java/org/apache/commons/compress/archivers/zip/*.java"
+  detected_license: "LicenseRef-scancode-proprietary-license"
+  reason: "REFERENCE"
+  comment: |-
+    This is a match on 'Refer to the section in this document entitled "Incorporating PKWARE Proprietary Technology into
+    Your Product" for more information', see
+    https://github.com/apache/commons-compress/blob/rel/commons-compress-1.26.2/src/main/java/org/apache/commons/compress/archivers/zip/X0017_StrongEncryptionHeader.java#L251-L252
+    Running Git blame on the line shows that this is a reference to the ZIP file format specification, see
+    https://github.com/apache/commons-compress/commit/a433f625f89c1d464b05186411ff20802e292fb4.
+  concluded_license: "NONE"


### PR DESCRIPTION
First and foremost, exclude `some-900kb-text.txt` [1] which just contains random text in a single line, which makes ScanCode time out.

Secondly, while at it, also exclude the `.github` build directory committed to VCS.

[1]: https://github.com/apache/commons-compress/blob/rel/commons-compress-1.26.2/src/test/resources/org/apache/commons/compress/COMPRESS-649/some-900kb-text.txt