### PR TITLE
feat(curations): Add a VCS curation for XMLUnit < 2.0

### DIFF
--- a/curations/Maven/xmlunit/xmlunit.yml
+++ b/curations/Maven/xmlunit/xmlunit.yml
@@ -1,7 +1,11 @@
 - id: "Maven:xmlunit:xmlunit:(,2.0["
   curations:
     comment: |-
-      Wrong SVN repository URL in POM: https://repo1.maven.org/maven2/xmlunit/xmlunit/1.3/xmlunit-1.3.pom
+      The POM, e.g. https://repo1.maven.org/maven2/xmlunit/xmlunit/1.3/xmlunit-1.3.pom, contains a `BSD-3-Clause`
+      license header but a non-SPDX license name tag. Also the SVN repository URL is wrong as it either points to the
+      view URL or hard-codes the trunk revision.
+    declared_license_mapping:
+      BSD License: "BSD-3-Clause"
     vcs:
       type: "Subversion"
       url: "https://svn.code.sf.net/p/xmlunit/code"

--- a/curations/Maven/xmlunit/xmlunit.yml
+++ b/curations/Maven/xmlunit/xmlunit.yml
@@ -1,0 +1,7 @@
+- id: "Maven:xmlunit:xmlunit:(,2.0["
+  curations:
+    comment: |-
+      Wrong SVN repository URL in POM: https://repo1.maven.org/maven2/xmlunit/xmlunit/1.3/xmlunit-1.3.pom
+    vcs:
+      type: "Subversion"
+      url: "https://svn.code.sf.net/p/xmlunit/code"


### PR DESCRIPTION
Note that XMLUnit 2.x is hosted at [1].

[1]: https://github.com/xmlunit/xmlunit