### PR TITLE
feat(curations): Set the VCS info for "PyPI::tensorflow-intel"

### DIFF
--- a/curations/PyPI/_/tensorflow-intel.yml
+++ b/curations/PyPI/_/tensorflow-intel.yml
@@ -1,0 +1,5 @@
+- id: "PyPI::tensorflow-intel:"
+  curations:
+    comment: No VCS information contained in metadata. The correct VCS URL was found via Internet search.
+    vcs:
+      url: "https://github.com/Intel-tensorflow/tensorflow.git"


### PR DESCRIPTION
FYI @haikoschol, this also has the https://github.com/Intel-tensorflow/tensorflow/tree/v2.12.0 tag.