### PR TITLE
xalan:xalan with Apache-2.0

### DIFF
--- a/curations/Maven/xalan/xalan.yml
+++ b/curations/Maven/xalan/xalan.yml
@@ -1,0 +1,6 @@
+- id: "Maven:xalan:xalan"
+  curations:
+    comment: |-
+      Sources found on GitHub.
+    vcs:
+      url: "https://github.com/apache/xalan-java.git"


### PR DESCRIPTION
Suggested curation for xalan:xalan Maven dependency. Motivated by this error:

```
Extensions:1.4'.
ERROR: NO_LICENSE_IN_DEPENDENCY - Maven:xalan:xalan:2.7.3 - No license information is available for dependency 'Maven:xalan:xalan:2.7.3'.
```