### PR TITLE
feat(evaluator.rules): Improve the unmapped declared license rule

### DIFF
--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1601,6 +1601,7 @@ fun RuleSet.unhandledLicenseRule() = packageRule("UNHANDLED_LICENSE") {
 fun RuleSet.unmappedDeclaredLicenseRule() = packageRule("UNMAPPED_DECLARED_LICENSE") {
     require {
         -isExcluded()
+        -hasConcludedLicense()
     }
 
     resolvedLicenseInfo.licenseInfo.declaredLicenseInfo.processed.unmapped.forEach { unmappedLicense ->


### PR DESCRIPTION
A concluded license overrides the applicable license including any declared license. So, do not report issues about the declared license if a concluded license is set.
