### PR TITLE
Revert "chore: Extend the "listenablefuture" curation to version 1.0"

### DIFF
--- a/curations/Maven/com.google.guava/listenablefuture.yml
+++ b/curations/Maven/com.google.guava/listenablefuture.yml
@@ -1,8 +1,3 @@
-- id: "Maven:com.google.guava:listenablefuture:1.0"
-  curations:
-    comment: |
-      This library is empty as its version string suggests.
-    is_metadata_only: true
 - id: "Maven:com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava"
   curations:
     comment: |


### PR DESCRIPTION
This reverts commit 7f2f13d as the artifacts in not really metadata-only / empty, but actually contains the `ListenableFuture` interface definition, see [1].

[1]: https://repo1.maven.org/maven2/com/google/guava/listenablefuture/1.0/listenablefuture-1.0-sources.jar