### PR TITLE
feat(curations): Add a VCS curation for NPM::three

### DIFF
--- a/curations/NPM/_/three.yml
+++ b/curations/NPM/_/three.yml
@@ -1,0 +1,5 @@
+- id: "NPM::three:0.178.0"
+  curations:
+    comment: "Commit of release 0.178.0 is tagged r178."
+    vcs:
+      revision: "3b1ff7661884f26e6d9af1d94c293129aaba885c"


### PR DESCRIPTION
three.js releases are tagged like this: `r<feature release>`, e.g. instead of 0.178.0 the tag says r178 and is not found by ort.