### PR TITLE
ci(renovate): Use the config preset from the .github repo

### DIFF
--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,0 +1,18 @@
+name: Renovate Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  renovate-validation:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Validate Renovate Config
+      run: npx -y --package renovate@latest -- renovate-config-validator renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver",
-    ":semanticCommitScopeDisabled",
-    ":semanticCommitTypeAll(deps)"
-  ],
-  "dependencyDashboard": false,
-  "labels": ["dependencies"]
+    "github>oss-review-toolkit/.github//renovate-config"
+  ]
 }


### PR DESCRIPTION
Also remove config options which are now inherited from the preset. See [1] for an explanation of the syntax.

[1]: https://docs.renovatebot.com/config-presets/#github