### PR TITLE
fix(text-templates): Re-align notice text templates with changes in ORT

### DIFF
--- a/text-templates/NOTICE_BY_PACKAGE.ftl
+++ b/text-templates/NOTICE_BY_PACKAGE.ftl
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@
 [#assign filteredLicenses = helper.filterForCategory(mergedLicenses, noticeCategoryName)]
 [#list filteredLicenses as resolvedLicense]
     [#assign licenseName = resolvedLicense.license.simpleLicense()]
-    [#assign licenseText = licenseTextProvider.getLicenseText(licenseName)!]
+    [#assign licenseText = licenseFactProvider.getLicenseText(licenseName)!]
     [#if !licenseText?has_content][#continue][/#if]
     [#if !hasNoticeProjectLicenses]
 This software includes external packages and source code.
@@ -54,7 +54,7 @@ The applicable license information is listed below:
 ${copyrights?join("\n", "", "\n")}
 ${licenseText}
     [#assign exceptionName = resolvedLicense.license.exception()!]
-    [#assign exceptionText = licenseTextProvider.getLicenseText(exceptionName)!]
+    [#assign exceptionText = licenseFactProvider.getLicenseText(exceptionName)!]
     [#if exceptionText?has_content]
 ${exceptionText}
     [/#if]
@@ -97,15 +97,15 @@ ${copyrights?join("\n", "")}
         are configured not to be included in notice files, and filter all licenses that are contained in the license
         files already printed above.
     --]
-    [#assign licensesFilteredBySource = LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.license.licenses)]
+    [#assign resolvedLicenseInfo = LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED.filter(package.license, package.licenseChoices)]
     [#assign resolvedLicenses = helper.filterForCategory(
-        package.licensesNotInLicenseFiles(licensesFilteredBySource),
+        package.licensesNotInLicenseFiles(resolvedLicenseInfo.licenses),
         noticeCategoryName
     )]
     [#assign isFirst = true]
     [#list resolvedLicenses as resolvedLicense]
         [#assign licenseName = resolvedLicense.license.simpleLicense()]
-        [#assign licenseText = licenseTextProvider.getLicenseText(licenseName)!]
+        [#assign licenseText = licenseFactProvider.getLicenseText(licenseName)!]
         [#if !licenseText?has_content][#continue][/#if]
         [#if isFirst]
             [#if !hasNoticePackageLicenses]
@@ -127,7 +127,7 @@ The following copyrights and licenses were found in the source code of this pack
 ${copyrights?join("\n", "", "\n")}
 ${licenseText}
         [#assign exceptionName = resolvedLicense.license.exception()!]
-        [#assign exceptionText = licenseTextProvider.getLicenseText(exceptionName)!]
+        [#assign exceptionText = licenseFactProvider.getLicenseText(exceptionName)!]
         [#if exceptionText?has_content]
 ${exceptionText}
         [/#if]

--- a/text-templates/NOTICE_SUMMARY.ftl
+++ b/text-templates/NOTICE_SUMMARY.ftl
@@ -5,7 +5,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ This project contains or depends on third-party software components pursuant to 
     )]
     [#list mergedLicenses as resolvedLicense]
         [#assign licenseName = resolvedLicense.license.simpleLicense()]
-        [#assign licenseText = licenseTextProvider.getLicenseText(licenseName)!]
+        [#assign licenseText = licenseFactProvider.getLicenseText(licenseName)!]
         [#if !licenseText?has_content][#continue][/#if]
         [#if isFirst]
             [#assign isFirst = false]
@@ -58,7 +58,7 @@ This project contains or depends on third-party software components pursuant to 
 ${copyrights?join("\n", "", "\n")}
 ${licenseText}
         [#assign exceptionName = resolvedLicense.license.exception()!]
-        [#assign exceptionText = licenseTextProvider.getLicenseText(exceptionName)!]
+        [#assign exceptionText = licenseFactProvider.getLicenseText(exceptionName)!]
         [#if exceptionText?has_content]
 ${exceptionText}
         [/#if]


### PR DESCRIPTION
Replace the file content with the one from [^1], except for the
copyright statement, which brings in the ORT commits af2a476, 4a7d58a,
d0bce72 and 60316b7.

This fixes the following error when executing the template:

```
FreeMarker template error:
The following has evaluated to null or missing:
==> licenseTextProvider
```

[^1]: https://github.com/oss-review-toolkit/ort/blob/800c14f246b9326a6e221f7c0f55dcf8257e2f64/plugins/reporters/freemarker/src/main/resources/templates/plain-text/NOTICE_DEFAULT.ftl
