### PR TITLE
chore: Re-generate license classifications

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -21,6 +21,7 @@ categories:
 - name: "generic"
 - name: "include-in-notice-file"
 - name: "include-source-code-offer-in-notice-file"
+- name: "non-commercial"
 - name: "patent-license"
 - name: "permissive"
 - name: "proprietary-free"
@@ -85,6 +86,10 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "ALGLIB-Documentation"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "AMD-newlib"
   categories:
   - "permissive"
@@ -174,15 +179,18 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "Advanced-Cryptics-Dictionary"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "Afmparse"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "Aladdin"
   categories:
-  - "copyleft"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "Apache-1.0"
   categories:
   - "permissive"
@@ -234,6 +242,10 @@ categorizations:
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
 - id: "Aspell-RU"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BOLA-1.1"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -313,6 +325,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "BSD-3-Clause-Tso"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "BSD-3-Clause-acpica"
   categories:
   - "permissive"
@@ -350,6 +366,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "BSD-Inferno-Nettverk"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "BSD-Mark-Modifications"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -440,6 +460,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "Buddy"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "C-UDA-1.0"
   categories:
   - "free-restricted"
@@ -454,6 +478,10 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "CAPEC-tou"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "CATOSL-1.1"
   categories:
   - "copyleft-limited"
@@ -509,95 +537,95 @@ categorizations:
   - "include-in-notice-file"
 - id: "CC-BY-NC-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-3.0-DE"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-3.0-DE"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-3.0-IGO"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-ND-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-2.0-DE"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-2.0-FR"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-2.0-UK"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-3.0-DE"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-3.0-IGO"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-NC-SA-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "CC-BY-ND-1.0"
   categories:
@@ -952,6 +980,18 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "ESA-PL-permissive-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ESA-PL-strong-copyleft-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ESA-PL-weak-copyleft-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "EUDatagrid"
   categories:
   - "permissive"
@@ -1024,11 +1064,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "FSL-1.1-ALv2"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "FSL-1.1-MIT"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "FTL"
   categories:
@@ -1314,6 +1354,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "HPND-SMC"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "HPND-UC"
   categories:
   - "permissive"
@@ -1370,6 +1414,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "HPND-sell-variant-critical-systems"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "HTMLTIDY"
   categories:
   - "permissive"
@@ -1417,6 +1465,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "ISC-Veillard"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "ISO-permission"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -1639,7 +1691,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-a-star-logic-memoire-temp"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-aardvark-py-2014"
   categories:
@@ -1655,9 +1707,8 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ac3filter"
   categories:
-  - "copyleft"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-accellera-systemc"
   categories:
   - "permissive"
@@ -1677,7 +1728,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-acm-sla"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-acroname-bdk"
   categories:
@@ -1693,7 +1744,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-activestate-community"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-activestate-community-2012"
   categories:
@@ -1705,7 +1756,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-activision-eula"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-actuate-birt-ihub-ftype-sla"
   categories:
@@ -1808,6 +1859,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-adobe-research-2026"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-adobe-scl"
   categories:
   - "permissive"
@@ -1858,14 +1913,12 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-afpl-8.0"
   categories:
-  - "copyleft"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-afpl-9.0"
   categories:
-  - "copyleft"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-ag-grid-enterprise"
   categories:
   - "commercial"
@@ -1884,7 +1937,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ago-private-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-agpl-1.0"
   categories:
@@ -1915,19 +1968,36 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-ai-sweden-llm-ai-model-2023"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aikido-dual-agpl-commercial"
+  categories:
+  - "copyleft"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-aixfunestudio-model-1.6"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-aladdin-md5"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-alasir"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-aldor-public-2.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-alexisisaac-freeware"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-alglib-documentation"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -1937,11 +2007,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-allen-institute-software-2018"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-alliance-open-media-patent-1.0"
   categories:
   - "patent-license"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-alphagenome-model-tou-2025"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-altermime"
   categories:
@@ -2034,6 +2108,14 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-answercarefully-tou-2025"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-anthropic-commercial-tos-2025"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-anti-capitalist-1.4"
   categories:
   - "free-restricted"
@@ -2084,7 +2166,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-apl-1.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-app-s2p"
   categories:
@@ -2096,7 +2178,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-apple-academic-lisa-os-3.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-apple-attribution"
   categories:
@@ -2152,16 +2234,19 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-aptana-1.0"
   categories:
-  - "copyleft-limited"
+  - "proprietary-free"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-arachni-psl-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-aravindan-premkumar"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-arcinstitute-state-nc-2025"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-argouml"
   categories:
@@ -2306,7 +2391,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-autosar-proprietary"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-avdpro-2023-10-30"
   categories:
@@ -2319,6 +2404,14 @@ categorizations:
 - id: "LicenseRef-scancode-aws-ip-2021"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-axoniq-osla-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-aydinnyunus-2025"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-baekmuk-fonts"
   categories:
@@ -2445,11 +2538,11 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-bittorrent-eula"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-bitwarden-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-bitzi-pd"
   categories:
@@ -2505,6 +2598,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-bosch-sensortec-2023"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-boutell-libgd-2021"
   categories:
   - "permissive"
@@ -2519,7 +2616,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-brad-martinez-vb-32"
   categories:
-  - "free-restricted"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-brakeman-public-use"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-brankas-open-license-1.0"
   categories:
@@ -2682,6 +2783,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-3-clause-tso"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-bsd-4-clause-shortened"
   categories:
   - "permissive"
@@ -2743,6 +2848,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-bsd-intel"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bsd-mark-modifications"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -2883,11 +2992,23 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-buddy"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-budibase-sqs-2023"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-bugsense-sdk"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-bytemark"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-bzip2-libbzip-1.0.4"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -3071,107 +3192,107 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-3.0-de"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0-at"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0-au"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0-de"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0-igo"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-nd-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-de"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-fr"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-uk"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.5"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-de"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-igo"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-us"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-sa-4.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nd-1.0"
   categories:
@@ -3263,11 +3384,11 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-cc-nc-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-nc-sampling-plus-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-nd-1.0"
   categories:
@@ -3300,7 +3421,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ccg-research-academic"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ccl-2026"
+  categories:
+  - "commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cclrc"
   categories:
@@ -3427,19 +3552,19 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-chameleon-research-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-charmpp-2019"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-charmpp-converse-2017"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-chartdirector-6.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-check-cvs"
   categories:
@@ -3472,7 +3597,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-christopher-velazquez"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-circlestone-labs-nc-1.0"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cisco-avch264-patent"
   categories:
@@ -3570,7 +3699,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cockroachdb-2024-10-01"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-code-credit-license-1.0.0"
   categories:
@@ -3601,6 +3730,10 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-cogvideox-2024"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-coil-1.0"
   categories:
   - "permissive"
@@ -3622,6 +3755,10 @@ categorizations:
 - id: "LicenseRef-scancode-commonj-timer"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-comodo-available-source-sal"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-compass"
   categories:
@@ -3691,7 +3828,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-couchbase-enterprise"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cpal-1.0"
   categories:
@@ -3794,6 +3931,10 @@ categorizations:
   categories:
   - "commercial"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-cuffs-dataset-2024"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-cups"
   categories:
   - "copyleft"
@@ -3858,6 +3999,10 @@ categorizations:
   - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-databricks-dbx-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-datajuggler-2019"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
@@ -3961,11 +4106,14 @@ categorizations:
   categories:
   - "commercial"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-directus-bsl-1.1"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-divx-open-1.0"
   categories:
-  - "copyleft-limited"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-divx-open-2.1"
   categories:
   - "copyleft-limited"
@@ -3992,11 +4140,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-dl-de-by-nc-1-0-de"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-dl-de-by-nc-1-0-en"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-dl-de-zero-2.0"
   categories:
@@ -4030,6 +4178,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-dokploy-dsal-1.0"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-dom4j"
   categories:
   - "permissive"
@@ -4039,6 +4191,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-dosa-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-dotcms-aug-2025"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
@@ -4126,7 +4282,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-dynarch-linkware"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ecfonts-1.0"
   categories:
@@ -4142,7 +4298,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ecl-gcl-2019"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-eclipse-sua-2001"
   categories:
@@ -4292,7 +4448,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-embedthis-evaluation"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-embedthis-extension"
   categories:
@@ -4322,11 +4478,19 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-engram-quest-plugin-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-enhydra-1.1"
   categories:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-enisa-legal-notice-2025"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-enlightenment"
   categories:
   - "permissive"
@@ -4383,6 +4547,18 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-esa-pl-permissive-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-esa-pl-strong-copyleft-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-esa-pl-weak-copyleft-2.4"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-esri"
   categories:
   - "commercial"
@@ -4429,11 +4605,15 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-examdiff"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-exaone-ai-model-1.1-nc"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-exaone-ai-model-1.2-nc"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-excelsior-jet-runtime"
   categories:
@@ -4472,6 +4652,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-fair-chemistry-v1"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-fair-source-0.9"
   categories:
   - "source-available"
@@ -4482,7 +4666,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fancyzoom"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fastbuild-2012-2020"
   categories:
@@ -4502,11 +4686,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fcl-1.0-apache-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fcl-1.0-mit"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ferguson-twofish"
   categories:
@@ -4537,6 +4721,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-fish-audio-research-2026-03-07"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-flex-2.5"
   categories:
   - "permissive"
@@ -4544,6 +4732,10 @@ categorizations:
 - id: "LicenseRef-scancode-flex2sdk"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-flexbyte"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-flora-1.1"
   categories:
@@ -4568,7 +4760,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-flux-1-nc"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-font-alias"
   categories:
@@ -4701,19 +4893,19 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fsl-1.0-apache-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fsl-1.0-mit"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fsl-1.1-apache-2.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fsl-1.1-mit"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ftdi"
   categories:
@@ -4729,15 +4921,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-futo-sfl-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-futo-sfl-1.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-futo-sfl-1.1-kb"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-fwlw"
   categories:
@@ -4761,15 +4953,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-gaussian-splatting-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-gcel-2022"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-gco-v3.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-gcr-docs"
   categories:
@@ -4806,7 +4998,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-generic-amiwm"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-generic-cla"
   categories:
@@ -4838,7 +5030,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-geogebra-ncla-2022"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-gfdl-1.1"
   categories:
@@ -4973,6 +5165,10 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-glm-130b"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-glulxe"
   categories:
   - "permissive"
@@ -5306,13 +5502,17 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-health-ai-developer-tou-2024"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-helios-eula"
   categories:
   - "commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-helix"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-henry-spencer-1999"
   categories:
@@ -5394,7 +5594,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-hp"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-hp-1986"
   categories:
@@ -5406,7 +5606,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-hp-netperf"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-hp-proliant-essentials"
   categories:
@@ -5472,11 +5672,19 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-hpnd-sell-variant-critical-systems"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-hpnd-sell-variant-mit-disclaimer"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-hpnd-sell-variant-mit-disclaimer-rev"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hpnd-smc"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -5519,6 +5727,10 @@ categorizations:
 - id: "LicenseRef-scancode-hyperclova-x-seed-2025"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-hyphen-bulgarian"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ian-kaplan"
   categories:
@@ -5643,7 +5855,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-imagen"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-imlib2"
   categories:
@@ -5717,15 +5929,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-inria-compcert"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-inria-icesl"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-inria-zelus"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-installsite"
   categories:
@@ -5791,6 +6003,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-intel-research-use-2024"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-intel-royalty-free"
   categories:
   - "permissive"
@@ -5843,6 +6059,10 @@ categorizations:
 - id: "LicenseRef-scancode-iso-recorder"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-iso-schematron-19757-3"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-isotope-cla"
   categories:
@@ -5916,11 +6136,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-java-research-1.5"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-java-research-1.6"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-jboss-eula"
   categories:
@@ -5945,11 +6165,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-jetbrains-toolbox-open-source-3"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-jetbrains-toolbox-oss-3"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-jetty"
   categories:
@@ -5976,7 +6196,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-jmagnetic"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-joinbase-cela-2022"
   categories:
@@ -5984,7 +6204,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-joplin-server-personal-v1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-josl-1.0"
   categories:
@@ -6067,6 +6287,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-kapivara-sal-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-karl-peterson"
   categories:
   - "free-restricted"
@@ -6117,6 +6341,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-keychron-sal-2024"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-keypirinha"
   categories:
   - "proprietary-free"
@@ -6147,7 +6375,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-kubesphere-osl-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-kumar-robotics"
   categories:
@@ -6254,6 +6482,10 @@ categorizations:
 - id: "LicenseRef-scancode-leptonica"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-lfm-open-1.0"
+  categories:
+  - "source-available"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-lgpl-2.0"
   categories:
@@ -6427,6 +6659,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-livekit-model-2024"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-llama-2-license-2023"
   categories:
   - "proprietary-free"
@@ -6453,7 +6689,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-llama-license-2023"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-llnl"
   categories:
@@ -6507,6 +6743,10 @@ categorizations:
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-lsi-proprietary-eula"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ltx-2-cla-2026"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
@@ -6598,7 +6838,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-mame"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-man2html"
   categories:
@@ -6683,11 +6923,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mcrae-pl-4-r53"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mdl-2021"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mediainfo-lib"
   categories:
@@ -6723,7 +6963,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-melange"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mentalis"
   categories:
@@ -6731,7 +6971,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-menuet64-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-meralion-pl-2025"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-merit-network-derivative"
   categories:
@@ -6740,7 +6984,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-metageek-inssider-eula"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-metamail"
   categories:
@@ -6754,6 +6998,10 @@ categorizations:
 - id: "LicenseRef-scancode-mgb-1.0"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-mgb-brainiac-nc-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mgopen-font-license"
   categories:
@@ -6793,11 +7041,23 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mike95"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-minecraft-mod"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-minimax-mit-variant-2025"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-minimax-model-m2.5"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-minimax-non-commercial-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-minpack"
   categories:
@@ -6926,6 +7186,10 @@ categorizations:
 - id: "LicenseRef-scancode-moderne-sala-2024"
   categories:
   - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-moe-speech"
+  categories:
+  - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-monetdb-1.1"
   categories:
@@ -7191,7 +7455,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ms-invisible-eula-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ms-jdbc-driver-40-sql-server"
   categories:
@@ -7327,11 +7591,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ms-research-license-terms"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ms-research-shared-source"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ms-rl"
   categories:
@@ -7575,6 +7839,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-mux0-sal-2026"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-mvt-1.1"
   categories:
   - "free-restricted"
@@ -7585,7 +7853,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-mxparser-dual-2024-05-19"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-n8n-ee-2022"
   categories:
@@ -7597,7 +7865,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nanoporetech-public-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nasa-1.3"
   categories:
@@ -7617,17 +7885,33 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-nc-gov-public-sector-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nc-gov-public-sector-2.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-ncbi"
   categories:
   - "public-domain"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ncgl-uk-2.0"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ncsa-httpd-1995"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ncsc-nl-disclaimer"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nemotron-open-model-2025-12-15"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nero-eula"
   categories:
@@ -7692,6 +7976,10 @@ categorizations:
 - id: "LicenseRef-scancode-newton-king-cla"
   categories:
   - "cla"
+- id: "LicenseRef-scancode-nexar-dataset-2025"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-nexb-eula-saas-1.1.0"
   categories:
   - "commercial"
@@ -7736,6 +8024,10 @@ categorizations:
 - id: "LicenseRef-scancode-nist-pd-fallback"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nist-pd-tnt"
+  categories:
+  - "public-domain"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nist-software"
   categories:
@@ -7854,6 +8146,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-ntuitive-la-2025"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-nucleusicons-eula"
   categories:
   - "proprietary-free"
@@ -7869,6 +8165,14 @@ categorizations:
 - id: "LicenseRef-scancode-nvidia"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-1-way-commercial"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-1-way-noncommercial"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nvidia-2002"
   categories:
@@ -7894,6 +8198,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-isaac-ros-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-nvidia-model-training-2025"
   categories:
   - "proprietary-free"
@@ -7903,6 +8211,10 @@ categorizations:
   - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nvidia-ngx-eula-2019"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-open-model-2025"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
@@ -7918,6 +8230,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-nvidia-source-code-nc-2024"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-nvidia-video-codec-agreement"
   categories:
   - "proprietary-free"
@@ -7929,6 +8245,10 @@ categorizations:
 - id: "LicenseRef-scancode-nxlog-public-license-1.0"
   categories:
   - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-nxml-pokemon-legends-za-nc-1.0"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-nxp-firmware-patent"
   categories:
@@ -7988,7 +8308,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ocamlpro-nc-v1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ocb-non-military-2013"
   categories:
@@ -8007,6 +8327,10 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-ocl-v1"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-oclc-1.0"
   categories:
   - "copyleft-limited"
@@ -8039,6 +8363,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-ocvsal-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-odb-cpl"
   categories:
   - "commercial"
@@ -8049,9 +8377,8 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-odb-ncuel"
   categories:
-  - "copyleft"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-odbl-1.0"
   categories:
   - "copyleft"
@@ -8117,11 +8444,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ofrak-community-1.0"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ofrak-community-1.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ofrak-pro-1.0"
   categories:
@@ -8209,7 +8536,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-onezoom-np-sal-v1"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ooura-2001"
   categories:
@@ -8217,7 +8544,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-open-aleph-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-open-diameter"
   categories:
@@ -8251,7 +8578,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-opencarp-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-opengroup"
   categories:
@@ -8359,9 +8686,8 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-openpbs-2.3"
   categories:
-  - "copyleft-limited"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-openpub"
   categories:
   - "permissive"
@@ -8427,9 +8753,13 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-opt-175b-2022"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-bcl-java-platform-2013"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-bcl-java-platform-2017"
   categories:
@@ -8449,7 +8779,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-bcl-javase-platform-javafx-2013"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-bcl-javase-platform-javafx-2017"
   categories:
@@ -8487,6 +8817,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-oracle-free-2021"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-gftc-2023-06-12"
   categories:
   - "proprietary-free"
@@ -8517,7 +8851,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oracle-web-sites-tou"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oreilly-notice"
   categories:
@@ -8530,6 +8864,14 @@ categorizations:
 - id: "LicenseRef-scancode-os4d-1.1-apache-2.0"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-osassy-2025"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-osc-1.0"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oset-pl-2.1"
   categories:
@@ -8576,11 +8918,15 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-ossn-3.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-ossp"
+  categories:
+  - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-osvdb"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-oswego-concurrent"
   categories:
@@ -8598,7 +8944,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-otn-dev-dist-2009"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-otn-dev-dist-2014"
   categories:
@@ -8610,11 +8956,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-otn-early-adopter-2018"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-otn-early-adopter-development"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-otn-standard-2014-09"
   categories:
@@ -8686,6 +9032,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-paratype-free-font-1.3"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-paraview-1.2"
   categories:
   - "permissive"
@@ -8702,7 +9052,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-passive-aggressive"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-patent-disclaimer"
   categories:
@@ -8742,6 +9092,10 @@ categorizations:
 - id: "LicenseRef-scancode-pbl-1.0"
   categories:
   - "free-restricted"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-pcgexelementszonegraph-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-pcre"
   categories:
@@ -8787,11 +9141,11 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-pftus-1.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-phaser-academic"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-phaser-ccp4"
   categories:
@@ -8833,13 +9187,17 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-pi-lab-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-pine"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-pipedream-sal-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-pivotal-tou"
   categories:
@@ -8852,6 +9210,10 @@ categorizations:
 - id: "LicenseRef-scancode-pixar"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-plamo-cla-2024"
+  categories:
+  - "source-available"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-planet-source-code"
   categories:
@@ -8881,6 +9243,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-poke-wiggle-proprietary-2026"
+  categories:
+  - "commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-politepix-pl-1.0"
   categories:
   - "permissive"
@@ -8899,7 +9265,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-polyform-noncommercial-1.0.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-polyform-perimeter-1.0.0"
   categories:
@@ -8915,7 +9281,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-polyform-strict-1.0.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-postgresql"
   categories:
@@ -8950,7 +9316,7 @@ categorizations:
   - "generic"
 - id: "LicenseRef-scancode-prosperity-1.0.1"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-prosperity-2.0"
   categories:
@@ -8958,7 +9324,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-prosperity-3.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-protobuf"
   categories:
@@ -9091,7 +9457,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-quadratic-sal-2024"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-qualcomm-iso"
   categories:
@@ -9105,13 +9471,17 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-quicknet-document-1999"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-quicktime"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-quin-street"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-quirksmode"
   categories:
@@ -9157,11 +9527,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rcsl-2.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rcsl-3.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rdisc"
   categories:
@@ -9213,7 +9583,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-research-disclaimer"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-responsible-ai-source-1.0"
   categories:
@@ -9223,6 +9593,10 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-resume-summarization-2025"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-retentioneering-2023"
   categories:
   - "proprietary-free"
@@ -9230,6 +9604,10 @@ categorizations:
 - id: "LicenseRef-scancode-retype-3.7.0"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rexgradient-nc"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rh-eula"
   categories:
@@ -9303,9 +9681,17 @@ categorizations:
   categories:
   - "commercial"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-roofsuit-2025"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-root-cert-3.0"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-rosetta-software-nc-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rpl-1.1"
   categories:
@@ -9336,7 +9722,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rsa-md2"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rsa-md4"
   categories:
@@ -9352,7 +9738,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rsalv2"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rtools-util"
   categories:
@@ -9381,7 +9767,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-rwth-returnn-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-ryszard-szopa"
   categories:
@@ -9389,7 +9775,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-s-lab-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-saas-mit"
   categories:
@@ -9409,13 +9795,17 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-salesforce-ai-ethics-2025"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-salesforce-au-external-2025"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-salesforcesans-font"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sam-2025-11-19"
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
@@ -9433,6 +9823,10 @@ categorizations:
 - id: "LicenseRef-scancode-sash"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sat-uk-choral-ai-1.0"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-sata"
   categories:
@@ -9453,6 +9847,10 @@ categorizations:
 - id: "LicenseRef-scancode-saxpath"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-saxs-synthetic-commercial-1.0"
+  categories:
+  - "commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-sbia-b"
   categories:
@@ -9480,15 +9878,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-scilab-en"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-scilab-en-2005"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-scilab-fr"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-scintilla"
   categories:
@@ -9520,17 +9918,19 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-scsl-2.8"
   categories:
-  - "copyleft-limited"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-scsl-3.0"
   categories:
-  - "copyleft-limited"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-scylladb-sla-1.0"
   categories:
   - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-seamless-2023"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-secret-labs-2011"
   categories:
@@ -9649,11 +10049,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-siesta-academic-individuals"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-siesta-computer-centres"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-silicon-image-2007"
   categories:
@@ -9677,6 +10077,10 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LicenseRef-scancode-skunkworks-varuna-stt"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-sl"
   categories:
   - "permissive"
@@ -9702,6 +10106,10 @@ categorizations:
   categories:
   - "free-restricted"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-slipnet-sal-2026"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-slysoft-eula"
   categories:
   - "commercial"
@@ -9722,7 +10130,11 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-smsc-non-commercial-2012"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-snap-nc-2025"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-snia"
   categories:
@@ -9732,6 +10144,10 @@ categorizations:
 - id: "LicenseRef-scancode-snmp4j-smi"
   categories:
   - "commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-snofs-1.1"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-snort-subscriber-rules-3.1"
   categories:
@@ -9747,11 +10163,15 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-snowplow-person-academic-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-snprintf"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-socigy-nc-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-socketxx-2003"
   categories:
@@ -9783,7 +10203,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-solace-software-eula-2020"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-soml-1.0"
   categories:
@@ -9791,6 +10211,10 @@ categorizations:
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-sonar-sal-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-sonar-sal-1.0.1"
   categories:
   - "source-available"
   - "include-in-notice-file"
@@ -9864,11 +10288,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-stability-ai-community-2024"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-stability-ai-nc-2023-12-06"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-stable-diffusion-2022-08-22"
   categories:
@@ -10104,7 +10528,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-sun-prop-non-commercial"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-sun-proprietary-jdk"
   categories:
@@ -10153,7 +10577,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-sustainable-use-1.0"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-svndiff"
   categories:
@@ -10234,6 +10658,10 @@ categorizations:
 - id: "LicenseRef-scancode-t-license-tkse"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tabpfn-2.6-v1.0"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-takao-abe"
   categories:
@@ -10318,9 +10746,13 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-tenable-nessus"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-tencent-hunyuan-3d-2.0-cla"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tencent-hunyuan-image-3.0-cla"
   categories:
   - "source-available"
   - "include-in-notice-file"
@@ -10387,6 +10819,10 @@ categorizations:
   categories:
   - "commercial"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-ti-text-file"
+  categories:
+  - "proprietary-free"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-tidy"
   categories:
   - "permissive"
@@ -10394,6 +10830,10 @@ categorizations:
 - id: "LicenseRef-scancode-tiger-crypto"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-tigerdataset-nc-2025"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-tigra-calendar-3.2"
   categories:
@@ -10494,7 +10934,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-triptracker"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-truecrypt-3.1"
   categories:
@@ -10511,7 +10951,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-tsl-2018"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-tsl-2020"
   categories:
@@ -10681,13 +11121,17 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-uofu-rfpl"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-uoi-ncsa"
   categories:
   - "permissive"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-upl-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-upstage-solar-2026-01-16"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -10726,7 +11170,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-vanderbilt-sla-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-vbaccelerator"
   categories:
@@ -10799,7 +11243,7 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-volla-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-vostrom"
   categories:
@@ -10830,7 +11274,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-vvvvvv-scl-1.0"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-w3c"
   categories:
@@ -10894,6 +11338,14 @@ categorizations:
   categories:
   - "free-restricted"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-weinbach-non-commercial-1.0"
+  categories:
+  - "non-commercial"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-wender-media-sal-1.0"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-westhawk"
   categories:
   - "permissive"
@@ -10905,6 +11357,10 @@ categorizations:
 - id: "LicenseRef-scancode-whitecat"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-whitedns-sal-nc-2026"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-whosonfirst-license"
   categories:
@@ -10965,6 +11421,10 @@ categorizations:
 - id: "LicenseRef-scancode-wordnet"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-writer-open-model-2024-05-31"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-wrox"
   categories:
@@ -11094,6 +11554,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-x11-no-permit-persons"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "LicenseRef-scancode-x11-oar"
   categories:
   - "permissive"
@@ -11154,9 +11618,13 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
-- id: "LicenseRef-scancode-xceed-community-2021"
+- id: "LicenseRef-scancode-xai-cla-2025"
   categories:
   - "proprietary-free"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-xceed-community-2021"
+  categories:
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-xdebug-1.03"
   categories:
@@ -11220,15 +11688,19 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-yahoo-browserplus-eula"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-yahoo-messenger-eula"
   categories:
-  - "proprietary-free"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-yale-cas"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "LicenseRef-scancode-yandexgpt-5-lite-8b-2025"
+  categories:
+  - "proprietary-free"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-yensdesign"
   categories:
@@ -11262,11 +11734,11 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-zeebe-community-1.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-zeebe-community-1.1"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-zeeff"
   categories:
@@ -11426,6 +11898,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "MIT-STK"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "MIT-Wu"
   categories:
   - "permissive"
@@ -11457,6 +11933,10 @@ categorizations:
 - id: "MMIXware"
   categories:
   - "permissive"
+  - "include-in-notice-file"
+- id: "MMPL-1.0.1"
+  categories:
+  - "proprietary-free"
   - "include-in-notice-file"
 - id: "MPEG-SSG"
   categories:
@@ -11569,7 +12049,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "NCGL-UK-2.0"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "NCL"
   categories:
@@ -11589,6 +12069,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "NIST-PD"
+  categories:
+  - "public-domain"
+  - "include-in-notice-file"
+- id: "NIST-PD-TNT"
   categories:
   - "public-domain"
   - "include-in-notice-file"
@@ -11844,6 +12328,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "OSC-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "OSET-PL-2.1"
   categories:
   - "copyleft-limited"
@@ -11874,11 +12362,18 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "OSSP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "OpenMDW-1.0"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "OpenPBS-2.3"
   categories:
-  - "copyleft-limited"
+  - "non-commercial"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "OpenSSL"
   categories:
   - "permissive"
@@ -11916,6 +12411,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "ParaType-Free-Font-1.3"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "Parity-6.0.0"
   categories:
   - "copyleft"
@@ -11936,7 +12435,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "PolyForm-Noncommercial-1.0.0"
   categories:
-  - "source-available"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "PolyForm-Small-Business-1.0.0"
   categories:
@@ -12039,6 +12538,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "SGMLUG-PM"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "SGP4"
   categories:
   - "permissive"
@@ -12109,7 +12612,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "SUL-1.0"
   categories:
-  - "free-restricted"
+  - "non-commercial"
   - "include-in-notice-file"
 - id: "SWL"
   categories:
@@ -12241,6 +12744,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "TekHVC"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "TermReadKey"
   categories:
   - "permissive"
@@ -12280,6 +12787,10 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "UnRAR"
+  categories:
+  - "source-available"
+  - "include-in-notice-file"
 - id: "Unicode-3.0"
   categories:
   - "permissive"
@@ -12326,6 +12837,10 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "Vixie-Cron"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "W3C"
   categories:
   - "permissive"
@@ -12335,6 +12850,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "W3C-20150513"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "WTFNMFPL"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -12350,6 +12869,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "WordNet"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "Wsuipa"
   categories:
   - "permissive"
@@ -12359,6 +12882,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "X11-distribute-modifications-variant"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "X11-no-permit-persons"
   categories:
   - "permissive"
   - "include-in-notice-file"
@@ -12527,6 +13054,10 @@ categorizations:
   - "permissive"
   - "include-in-notice-file"
 - id: "hdparm"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
+- id: "hyphen-bulgarian"
   categories:
   - "permissive"
   - "include-in-notice-file"


### PR DESCRIPTION
The updated content was generated by [1].

[1] ./gradlew generateLicenseClassifications
